### PR TITLE
Adding support for central VPCs

### DIFF
--- a/.header.md
+++ b/.header.md
@@ -1,8 +1,32 @@
 # AWS Cloud WAN Module
 
-This module can be used to deploy an [AWS Cloud WAN](https://docs.aws.amazon.com/vpc/latest/cloudwan/what-is-cloudwan.html) network - with the Core Network as main resource. A Global Network (the high-level container for the Core Network), it is also created if required.
+This module can be used to deploy an [AWS Cloud WAN](https://docs.aws.amazon.com/vpc/latest/cloudwan/what-is-cloudwan.html) network - with the Core Network as main resource. A Global Network (the high-level container for the Core Network), can also be created if required.
 
-## Usage
+In addition, the module abstracts Central VPCs' creation and Core Network attachment - with the Global Network and Core Network created either within or outside the same module definition. Central VPC types supported are Inspection, Egress (with or without inspection), Ingress (with or without inspection), and Shared Services. Below you can find more information about the format and definition of each VPC type.
+
+## Global Network and Core Network
+
+Two variables - `var.global_network` and `var.core_network` - are used to define the Global Network and Core Network. Starting with the **Global Network**, the following attributes can be configured:
+
+- `description` = (string) Global Network's description.
+- `tags`        = (Optional|map(string)) Tags to apply to the Global Network resource.
+
+If a Global Network is already created and it is desired to pass only the resource ID to create a Core Network, use the `var.global_network_id` variable.
+
+Following with the **Core Network**, the following attributes can be configured:
+
+- `description`                              = (string) Core Network's description.
+- `policy_document`                          = (any) Core Network's policy in JSON format. It is recommended the use of the [Core Network Document data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document).
+- `base_policy_document`                     = (Optional|any) Conflicts with `base_policy_regions`. Sets the base policy document for the Core Network. For more information about the need of the base policy, check the [*When do I need to create the base_policy?*](#when-do-i-need-to-create-the-base_policy) section below.
+- `base_policy_regions`                      = (Optional|list(string)) Conflicts with `base_policy_document`. List of AWS Regions to create the base policy document in the Core Network. For more information about the need of the base policy, check the [*When do I need to create the base_policy?*](#when-do-i-need-to-create-the-base_policy) section below.
+- `resource_share_name`                      = (Optional|string) AWS Resource Access Manager (RAM) Resource Share name. Providing this value, RAM resources will be created to share the Core Network with the principals indicated in `var.core_network.ram_share_principals`.
+- `resource_share_allow_external_principals` = (Optional|bool) Indicates whether principals outside your AWS Organization can be associated with a Resource Share.
+- `ram_share_principals`                     = (Optional|list(string)) List of principals (AWS Account or AWS Organization) to share the Core Network with.
+- `tags`                                     = (Optional|map(string)) Tags to apply to the Core Network and RAM Resource Share (if created) resources.
+
+If a Core Network is already created and it is desired to pass only the resource ARN to attach Central VPCs, use the `var.core_network_arn` variable.
+
+### Examples
 
 The example below builds an AWS Network Manager Global Network and Core Network from scratch. The Core Network needs the ID of the Global Network created, and also a policy document (to define the global infrastructure). You can find more information about the policy document in the [documentation](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policy-change-sets.html)
 
@@ -92,9 +116,9 @@ module "cloud_wan" {
 }
 ```
 
-## Policy Creation
+### Policy Creation
 
-Policy documents can be passed as a string of JSON or using the [policy_document data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document)
+Policy documents can be passed as a string of JSON or using the [policy_document data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document) (recommended option).
 
 ```hcl
 data "aws_networkmanager_core_network_policy_document" "policy" {
@@ -138,7 +162,362 @@ data "aws_networkmanager_core_network_policy_document" "policy" {
 }
 ```
 
-## When do I need to create the *base_policy*?
+## Network definition
+
+The variable `var.ipv4_network_definition` is an attribute to configure a supernet (IPv4 CIDR block) or [managed prefix list](https://docs.aws.amazon.com/vpc/latest/userguide/managed-prefix-lists.html) of your network/VPCs in AWS. This variable is used when configuring VPC routing in some central VPCs. When checking the different VPC types below, you can check whether this variable is required or not.
+
+## Central VPCs
+
+Aside the creation of the Global Network and Core Network, this module also abstracts the creation of Central VPCs - and the attachment to the Core Network. The variable `var.central_vpcs` can be configured with a map of VPC definitions, with the following attributes:
+
+- `type`                     = (string) VPC type (`inspection`, `egress`, `egress_with_inspection`, `ingress`, `ingress_with_inspection`, `shared_services`) - each one of them with a specific VPC routing. For more information about the configuration of each VPC type, check each Central VPC type section below.
+- `name`                     = (Optional|string) Name of the VPC. If not defined, the key of the map will be used.
+- `cidr_block`               = (Optional|string) IPv4 CIDR range. **Cannot set if vpc_ipv4_ipam_pool_id is set.**
+- `vpc_ipv4_ipam_pool_id`    = (Optional|string) Set to use IPAM to get an IPv4 CIDR block.  **Cannot set if cidr_block is set.**
+- `vpc_ipv4_netmask_length`  = (Optional|number) Set to use IPAM to get an IPv4 CIDR block using a specified netmask. Must be set with `var.vpc_ipv4_ipam_pool_id`.
+- `az_count`                 = (number) Searches the number of AZs in the region and takes a slice based on this number - the slice is sorted a-z.
+- `vpc_enable_dns_hostnames` = (Optional|bool) Indicates whether the instances launched in the VPC get DNS hostnames. Enabled by default.
+- `vpc_enable_dns_support`   = (Optional|bool) Indicates whether the DNS resolution is supported for the VPC. If enabled, queries to the Amazon provided DNS server at the 169.254.169.253 IP address, or the reserved IP address at the base of the VPC network range "plus two" succeed. If disabled, the Amazon provided DNS service in the VPC that resolves public DNS hostnames to IP addresses is not enabled. Enabled by default.
+- `vpc_instance_tenancy`     = (Optional|string) The allowed tenancy of instances launched into the VPC.
+- `vpc_flow_logs`            = (Optional|object(any)) Configuration of the VPC Flow Logs of the VPC configured. Options: "cloudwatch", "s3", "none".
+- `subnets`                  = (any) Configuration of the subnets to create in the VPC - a map of subnets' definition is expected. Depending the VPC type, the format (subnets to configure and resources created by the module) will be different. Check each Central VPC type section below. for more information. 
+- `tags`                     = (Optional|map(string)) Tags to apply to all the Central VPC resources.
+
+To simplify the definition of this module, the following [VPC module](https://registry.terraform.io/modules/aws-ia/vpc/aws/latest) is used to create the VPC resources. We recommend to review its README to have more information about its inputs and outputs.
+
+### Inspection VPC
+
+Defining the type **inspection** will create specific VPC subnets and routing to create a central Inspection VPC - specific for East/West traffic inspection. When defining the VPC subnets (attribute `subnets`) two keys are mandatory: **endpoints** - to place the [AWS Network Firewall](https://aws.amazon.com/network-firewall/) or [Gateway Load Balancer](https://aws.amazon.com/elasticloadbalancing/gateway-load-balancer/) endpoints - and **core_network** - to place the Core Network attachment ENIs -. You are free to create additional subnets, but default configuration and VPC routing won't be created on them.
+
+When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for the **core_network** subnet type:
+
+- `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `true`.
+- `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+- `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, a default route (0.0.0.0/0) is created in the **endpoints** subnet type pointing to the Core Network attachment. Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the *core_network* subnet type to the firewall endpoints.
+
+```hcl
+module "inspection_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  central_vpcs = {
+    inspection-east-west = {
+      type       = "inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { cidrs = ["10.10.0.0/28", "10.10.0.16/28"] }
+        core_network = {
+          cidrs = ["10.10.0.32/28", "10.10.0.48/28"]
+
+          tags = { domain = "inspection" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Egress VPC
+
+Defining the type **egress** will create specific VPC subnets and routing to create a central Egress VPC. When defining the VPC subnets (attribute `subnets`) two keys are mandatory: **public** - to place the [NAT gateways](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html) or [NAT instances](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html) - and **core_network** - to place the Core Network attachment ENIs -. You are free to create additional subnets, but default configuration and VPC routing won't be created on them.
+
+When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for both the **public** and **core_network** subnet types:
+
+- Public subnets (*public*)
+  - `nat_gateway_configuration` = (Optional|string) Determines if NAT Gateways should be created and in how many AZs. Valid values = `"none"`, `"single_az"`, `"all_azs"` (default).
+  - `map_public_ip_on_launch`   = (Optional|bool) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default to `false`.
+- Core Network subnets (*core_network*)
+  - `connect_to_public_natgw` = (Optional|bool) Determines if a default route to NAT Gateways should be created. Defaults to `true`.
+  - `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `false`.
+  - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+  - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the *core_network* subnet type creates a default route (0.0.0.0/0) from the Core Network subnets to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
+
+```hcl
+module "egress_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  ipv4_network_definition = "10.0.0.0/8"
+
+  central_vpcs = {
+    central-egress = {
+      type       = "egress"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        public = { cidrs = ["10.10.0.0/28", "10.10.0.16/28"] }
+        core_network = {
+          cidrs = ["10.10.0.32/28", "10.10.0.48/28"]
+
+          tags = { domain = "egress" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Egress VPC (with inspection)
+
+Defining the type **egress_with_inspection** will create specific VPC subnets and routing to create a central Egress VPC with subnets to add an inspection layer between the Core Network attachment and the public subnets - to inspect egress traffic. When defining the VPC subnets (attribute `subnets`) three keys are mandatory:
+
+- **public** to place the [NAT gateways](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html) or [NAT instances](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html)
+- **endpoints** to place the [AWS Network Firewall](https://aws.amazon.com/network-firewall/) or [Gateway Load Balancer](https://aws.amazon.com/elasticloadbalancing/gateway-load-balancer/) endpoints.
+- **core_network** to place the Core Network attachment ENIs. 
+
+You are free to create additional subnets, but default configuration and VPC routing won't be created on them. When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for the **public**, **endpoints**, and **core_network** subnet types:
+
+- Public subnets (*public*)
+  - `nat_gateway_configuration` = (Optional|string) Determines if NAT Gateways should be created and in how many AZs. Valid values = `"none"`, `"single_az"`, `"all_azs"` (default).
+  - `map_public_ip_on_launch`   = (Optional|bool) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default to `false`.
+- Endpoint subnets (*endpoints*)
+  - `connect_to_public_natgw` = (Optional|bool) Determines if routes to NAT Gateways should be created. Defaults to `true`.
+- Core Network subnets (*core_network*)
+  - `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `true`.
+  - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+  - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the *endpoints* subnet type creates a default route (0.0.0.0/0) from the Endpoint subnets to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Endpoint subnets. 
+
+Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the *public* and *core_network* subnet types to the firewall endpoints.
+
+```hcl
+module "egress_with_inspection_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  ipv4_network_definition = "10.0.0.0/8"
+
+  central_vpcs = {
+    central-egress-inspection = {
+      type       = "egress_with_inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        public    = { netmask = 28 }
+        endpoints = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "egress" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Ingress VPC 
+
+Defining the type **ingress** will create specific VPC subnets and routing to create a central Ingress VPC. When defining the VPC subnets (attribute `subnets`) two keys are mandatory: **public** - to place the [Elastic Load Balancers](https://aws.amazon.com/elasticloadbalancing/) or your own ingress solution - and **core_network** - to place the Core Network attachment ENIs -. You are free to create additional subnets, but default configuration and VPC routing won't be created on them.
+
+When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for both the **public** and **core_network** subnet types:
+
+- Public subnets (*public*)
+  - `connect_to_igw`          = (Optional|bool) Determines if the default route (0.0.0.0/0) is created in the public subnets with destination the Internet gateway. Defaults to `true`.
+  - `map_public_ip_on_launch` = (Optional|bool) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default to `false`.
+- Core Network subnets (*core_network*)
+  - `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `false`.
+  - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+  - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
+
+```hcl
+module "egress_with_inspection_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  ipv4_network_definition = "10.0.0.0/8"
+
+  central_vpcs = {
+    ingress = {
+      type       = "ingress"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        public = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "ingress" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Ingress VPC (with inspection)
+
+Defining the type **ingress_with_inspection** will create specific VPC subnets and routing to create a central Ingress VPC with subnets to add an inspection layer between the Internet gateway and the public subnets - to inspect ingress traffic. When defining the VPC subnets (attribute `subnets`) three keys are mandatory:
+
+- **endpoints** to place the [AWS Network Firewall](https://aws.amazon.com/network-firewall/) or [Gateway Load Balancer](https://aws.amazon.com/elasticloadbalancing/gateway-load-balancer/) endpoints.
+- **public** to place the [Elastic Load Balancers](https://aws.amazon.com/elasticloadbalancing/) or your own ingress solution.
+- **core_network** to place the Core Network attachment ENIs. 
+
+You are free to create additional subnets, but default configuration and VPC routing won't be created on them. When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for both the **public** and **core_network** subnet types:
+
+- Public subnets (*public*)
+  - `connect_to_igw`          = (Optional|bool) Determines if the default route (0.0.0.0/0) is created in the public subnets with destination the Internet gateway. Defaults to `false`.
+  - `map_public_ip_on_launch` = (Optional|bool) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default to `false`.
+- Core Network subnets (*core_network*)
+  - `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `false`.
+  - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+  - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
+
+Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the [Internet gateway](https://aws.amazon.com/blogs/aws/new-vpc-ingress-routing-simplifying-integration-of-third-party-appliances/) and *core_network* subnet types to the firewall endpoints.
+
+```hcl
+module "egress_with_inspection_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  ipv4_network_definition = "10.0.0.0/8"
+
+  central_vpcs = {
+    ingress-with-inspection = {
+      type       = "ingress_with_inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { netmask = 28 }
+        public    = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "ingress" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Shared Services VPC
+
+Defining the type **shared_services** will create specific VPC subnets and routing to create a central Shared Services VPC. When defining the VPC subnets (attribute `subnets`) the only mandatory key is **core_network** - to place the Core Network attachment ENIs. When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for both the **core_network** subnet type:
+
+- `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `false`.
+- `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+- `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, a default route (0.0.0.0/0) poiting to the Core Network attachment will be created in any private subnet you create.
+
+```hcl
+module "egress_with_inspection_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  central_vpcs = {
+    shared-services = {
+      type       = "shared_services"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        vpc_endpoints = { netmask = 28 }
+        hybrid_dns    = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "shared" }
+        }
+      }
+    }
+  }
+}
+```
+
+## Common questions
+
+### How can I configure tags in the Core Network attachment?
+
+AWS Cloud WAN automates the association of an attachment to a specific segment, reducing the operational overhead specially in multi-Account environments. If you check how to define a [core network policy](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policies-json.html), you will see that the parameter **attachment-policies** is where you can define how to automate the associations. What can you use to define the attachment's association policy? You can use the Resource ID, Account ID, AWS Region, Attachment Type, and **Tags** - which is the common item to use.
+
+Now that we have explained the importance of tags when creating Core Network attachments, how can I create these tags using the module? As we use the following [VPC module](https://registry.terraform.io/modules/aws-ia/vpc/aws/latest) to create the central VPCs, the tags defined under the **core_network** subnet type will be applied to the Core Network attachment.
+
+```hcl
+core_network = {
+  netmask = 28
+
+  tags = { domain = "segment" }
+}
+```
+
+### Should I create Central VPCs in the same module definition as the Core Network?
+
+This module has been created to be used once per AWS Region you are creating resources - only 1 provider can be configured. This means that, if you want to create Central VPCs in several AWS Regions, you should have 1 module definition per Region. What about the Global Network and Core Network? These resources are global, and they can be created using a provider definition from any Region - of course, where [Cloud WAN is available](https://docs.aws.amazon.com/network-manager/latest/cloudwan/what-is-cloudwan.html#cloudwan-available-regions). **Important to note that whatever Region you configure for the provider that creates the Cloud WAN resources, the [home region](https://docs.aws.amazon.com/network-manager/latest/cloudwan/what-is-cloudwan.html#cloudwan-home-region) will be US West (Oregon)**.
+
+Coming back to the question, our recommendation is to create the Global Network and Core Network in a different module definition than the Central VPCs - even if the provider you use to create the global resource is also used to create Central VPCs in that same Region. The main reason of the recommendation is to decouple the definition of global and regional resources. That said, if you want to use the same module definition to create global resources and central VPCs in the Region the provider has configured, the module will allow you to do it (and it's not an anti-pattern).
+
+### When do I need to create the *base_policy*?
 
 You will see two attributes when defining the `var.core_network` variable are *base_policy_document* and *base_policy_regions*, used in the module to define the *base_policy*, *base_policy_document*, and *base_policy_regions* attributes in the `aws_networkmanager_core_network` resource. But... why do we need the *base_policy*?
 
@@ -163,3 +542,32 @@ You have two ways to define the *base_policy*:
 
 * Step 1: Update and apply the policy document with the new AWS Region(s).
 * Step 2: Create the new attachment(s) and update the policy document if any static route is needed.
+
+## Troubleshooting
+
+### Error: creating Network Manager VPC Attachment: ValidationException: A live policy was not found
+
+If you are creating for the first time the Core Network and the Central VPCs using the module, you will get the following error:
+
+```
+Error: creating Network Manager VPC (arn:aws:ec2:XXXXXXX-X:XXXXXXX:vpc/vpc-XXXXXXX) Attachment (core-network-XXXXXXX): ValidationException: A live policy was not found
+```
+
+This error is thrown because when creating the Core Network two resources are created: `aws_networkmanager_core_network` (main resource) and `aws_networkmanager_core_network_policy_attachment` (policy attachment). When creating the VPC attachments, the first resource is the one reference so when it finishes to be created, Terraform will try to create the attachment without waiting for the policy to be LIVE - hence the error. *You won't experience this error if the central VPCs are defined in the same module definition as the Core Network.*
+
+How to avoid the error? You can do two things:
+
+- If you create the Core Network using this module, but in a separate definition, you can use the [target](https://developer.hashicorp.com/terraform/tutorials/state/resource-targeting) option to create first the Core Network policy attachment resource.
+- If you create the Core Network using directly the provider resources, you can use a [depends_on](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) argument in the module definition to wait for the policy attachment to be created (LIVE) before start creating the central VPCs.
+
+### Creating Central VPCs with IPAM configuration - The "for_each" map includes keys derived from resource attributes that cannot be determined until apply
+
+When creating Central VPCs referencing an IPAM pool ID, you get the following error:
+
+```
+The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.
+When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values.
+Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
+```
+
+As described in the error itself, you first need to create the IPAM pool to then later create the VPCs. You can use the [target](https://developer.hashicorp.com/terraform/tutorials/state/resource-targeting) option if the IPAM resources are created in the same document (and state file) as the VPCs.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,33 @@
 <!-- BEGIN_TF_DOCS -->
 # AWS Cloud WAN Module
 
-This module can be used to deploy an [AWS Cloud WAN](https://docs.aws.amazon.com/vpc/latest/cloudwan/what-is-cloudwan.html) network - with the Core Network as main resource. A Global Network (the high-level container for the Core Network), it is also created if required.
+This module can be used to deploy an [AWS Cloud WAN](https://docs.aws.amazon.com/vpc/latest/cloudwan/what-is-cloudwan.html) network - with the Core Network as main resource. A Global Network (the high-level container for the Core Network), can also be created if required.
 
-## Usage
+In addition, the module abstracts Central VPCs' creation and Core Network attachment - with the Global Network and Core Network created either within or outside the same module definition. Central VPC types supported are Inspection, Egress (with or without inspection), Ingress (with or without inspection), and Shared Services. Below you can find more information about the format and definition of each VPC type.
+
+## Global Network and Core Network
+
+Two variables - `var.global_network` and `var.core_network` - are used to define the Global Network and Core Network. Starting with the **Global Network**, the following attributes can be configured:
+
+- `description` = (string) Global Network's description.
+- `tags`        = (Optional|map(string)) Tags to apply to the Global Network resource.
+
+If a Global Network is already created and it is desired to pass only the resource ID to create a Core Network, use the `var.global_network_id` variable.
+
+Following with the **Core Network**, the following attributes can be configured:
+
+- `description`                              = (string) Core Network's description.
+- `policy_document`                          = (any) Core Network's policy in JSON format. It is recommended the use of the [Core Network Document data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document).
+- `base_policy_document`                     = (Optional|any) Conflicts with `base_policy_regions`. Sets the base policy document for the Core Network. For more information about the need of the base policy, check the [*When do I need to create the base\_policy?*](#when-do-i-need-to-create-the-base\_policy) section below.
+- `base_policy_regions`                      = (Optional|list(string)) Conflicts with `base_policy_document`. List of AWS Regions to create the base policy document in the Core Network. For more information about the need of the base policy, check the [*When do I need to create the base\_policy?*](#when-do-i-need-to-create-the-base\_policy) section below.
+- `resource_share_name`                      = (Optional|string) AWS Resource Access Manager (RAM) Resource Share name. Providing this value, RAM resources will be created to share the Core Network with the principals indicated in `var.core_network.ram_share_principals`.
+- `resource_share_allow_external_principals` = (Optional|bool) Indicates whether principals outside your AWS Organization can be associated with a Resource Share.
+- `ram_share_principals`                     = (Optional|list(string)) List of principals (AWS Account or AWS Organization) to share the Core Network with.
+- `tags`                                     = (Optional|map(string)) Tags to apply to the Core Network and RAM Resource Share (if created) resources.
+
+If a Core Network is already created and it is desired to pass only the resource ARN to attach Central VPCs, use the `var.core_network_arn` variable.
+
+### Examples
 
 The example below builds an AWS Network Manager Global Network and Core Network from scratch. The Core Network needs the ID of the Global Network created, and also a policy document (to define the global infrastructure). You can find more information about the policy document in the [documentation](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policy-change-sets.html)
 
@@ -91,9 +115,9 @@ module "cloud_wan" {
 }
 ```
 
-## Policy Creation
+### Policy Creation
 
-Policy documents can be passed as a string of JSON or using the [policy\_document data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document)
+Policy documents can be passed as a string of JSON or using the [policy\_document data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document) (recommended option).
 
 ```hcl
 data "aws_networkmanager_core_network_policy_document" "policy" {
@@ -137,7 +161,362 @@ data "aws_networkmanager_core_network_policy_document" "policy" {
 }
 ```
 
-## When do I need to create the *base\_policy*?
+## Network definition
+
+The variable `var.ipv4_network_definition` is an attribute to configure a supernet (IPv4 CIDR block) or [managed prefix list](https://docs.aws.amazon.com/vpc/latest/userguide/managed-prefix-lists.html) of your network/VPCs in AWS. This variable is used when configuring VPC routing in some central VPCs. When checking the different VPC types below, you can check whether this variable is required or not.
+
+## Central VPCs
+
+Aside the creation of the Global Network and Core Network, this module also abstracts the creation of Central VPCs - and the attachment to the Core Network. The variable `var.central_vpcs` can be configured with a map of VPC definitions, with the following attributes:
+
+- `type`                     = (string) VPC type (`inspection`, `egress`, `egress_with_inspection`, `ingress`, `ingress_with_inspection`, `shared_services`) - each one of them with a specific VPC routing. For more information about the configuration of each VPC type, check each Central VPC type section below.
+- `name`                     = (Optional|string) Name of the VPC. If not defined, the key of the map will be used.
+- `cidr_block`               = (Optional|string) IPv4 CIDR range. **Cannot set if vpc\_ipv4\_ipam\_pool\_id is set.**
+- `vpc_ipv4_ipam_pool_id`    = (Optional|string) Set to use IPAM to get an IPv4 CIDR block.  **Cannot set if cidr\_block is set.**
+- `vpc_ipv4_netmask_length`  = (Optional|number) Set to use IPAM to get an IPv4 CIDR block using a specified netmask. Must be set with `var.vpc_ipv4_ipam_pool_id`.
+- `az_count`                 = (number) Searches the number of AZs in the region and takes a slice based on this number - the slice is sorted a-z.
+- `vpc_enable_dns_hostnames` = (Optional|bool) Indicates whether the instances launched in the VPC get DNS hostnames. Enabled by default.
+- `vpc_enable_dns_support`   = (Optional|bool) Indicates whether the DNS resolution is supported for the VPC. If enabled, queries to the Amazon provided DNS server at the 169.254.169.253 IP address, or the reserved IP address at the base of the VPC network range "plus two" succeed. If disabled, the Amazon provided DNS service in the VPC that resolves public DNS hostnames to IP addresses is not enabled. Enabled by default.
+- `vpc_instance_tenancy`     = (Optional|string) The allowed tenancy of instances launched into the VPC.
+- `vpc_flow_logs`            = (Optional|object(any)) Configuration of the VPC Flow Logs of the VPC configured. Options: "cloudwatch", "s3", "none".
+- `subnets`                  = (any) Configuration of the subnets to create in the VPC - a map of subnets' definition is expected. Depending the VPC type, the format (subnets to configure and resources created by the module) will be different. Check each Central VPC type section below. for more information.
+- `tags`                     = (Optional|map(string)) Tags to apply to all the Central VPC resources.
+
+To simplify the definition of this module, the following [VPC module](https://registry.terraform.io/modules/aws-ia/vpc/aws/latest) is used to create the VPC resources. We recommend to review its README to have more information about its inputs and outputs.
+
+### Inspection VPC
+
+Defining the type **inspection** will create specific VPC subnets and routing to create a central Inspection VPC - specific for East/West traffic inspection. When defining the VPC subnets (attribute `subnets`) two keys are mandatory: **endpoints** - to place the [AWS Network Firewall](https://aws.amazon.com/network-firewall/) or [Gateway Load Balancer](https://aws.amazon.com/elasticloadbalancing/gateway-load-balancer/) endpoints - and **core\_network** - to place the Core Network attachment ENIs -. You are free to create additional subnets, but default configuration and VPC routing won't be created on them.
+
+When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core\_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for the **core\_network** subnet type:
+
+- `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `true`.
+- `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+- `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, a default route (0.0.0.0/0) is created in the **endpoints** subnet type pointing to the Core Network attachment. Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the *core\_network* subnet type to the firewall endpoints.
+
+```hcl
+module "inspection_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  central_vpcs = {
+    inspection-east-west = {
+      type       = "inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { cidrs = ["10.10.0.0/28", "10.10.0.16/28"] }
+        core_network = {
+          cidrs = ["10.10.0.32/28", "10.10.0.48/28"]
+
+          tags = { domain = "inspection" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Egress VPC
+
+Defining the type **egress** will create specific VPC subnets and routing to create a central Egress VPC. When defining the VPC subnets (attribute `subnets`) two keys are mandatory: **public** - to place the [NAT gateways](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html) or [NAT instances](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html) - and **core\_network** - to place the Core Network attachment ENIs -. You are free to create additional subnets, but default configuration and VPC routing won't be created on them.
+
+When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core\_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for both the **public** and **core\_network** subnet types:
+
+- Public subnets (*public*)
+  - `nat_gateway_configuration` = (Optional|string) Determines if NAT Gateways should be created and in how many AZs. Valid values = `"none"`, `"single_az"`, `"all_azs"` (default).
+  - `map_public_ip_on_launch`   = (Optional|bool) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default to `false`.
+- Core Network subnets (*core\_network*)
+  - `connect_to_public_natgw` = (Optional|bool) Determines if a default route to NAT Gateways should be created. Defaults to `true`.
+  - `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `false`.
+  - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+  - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the *core\_network* subnet type creates a default route (0.0.0.0/0) from the Core Network subnets to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
+
+```hcl
+module "egress_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  ipv4_network_definition = "10.0.0.0/8"
+
+  central_vpcs = {
+    central-egress = {
+      type       = "egress"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        public = { cidrs = ["10.10.0.0/28", "10.10.0.16/28"] }
+        core_network = {
+          cidrs = ["10.10.0.32/28", "10.10.0.48/28"]
+
+          tags = { domain = "egress" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Egress VPC (with inspection)
+
+Defining the type **egress\_with\_inspection** will create specific VPC subnets and routing to create a central Egress VPC with subnets to add an inspection layer between the Core Network attachment and the public subnets - to inspect egress traffic. When defining the VPC subnets (attribute `subnets`) three keys are mandatory:
+
+- **public** to place the [NAT gateways](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html) or [NAT instances](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html)
+- **endpoints** to place the [AWS Network Firewall](https://aws.amazon.com/network-firewall/) or [Gateway Load Balancer](https://aws.amazon.com/elasticloadbalancing/gateway-load-balancer/) endpoints.
+- **core\_network** to place the Core Network attachment ENIs.
+
+You are free to create additional subnets, but default configuration and VPC routing won't be created on them. When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core\_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for the **public**, **endpoints**, and **core\_network** subnet types:
+
+- Public subnets (*public*)
+  - `nat_gateway_configuration` = (Optional|string) Determines if NAT Gateways should be created and in how many AZs. Valid values = `"none"`, `"single_az"`, `"all_azs"` (default).
+  - `map_public_ip_on_launch`   = (Optional|bool) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default to `false`.
+- Endpoint subnets (*endpoints*)
+  - `connect_to_public_natgw` = (Optional|bool) Determines if routes to NAT Gateways should be created. Defaults to `true`.
+- Core Network subnets (*core\_network*)
+  - `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `true`.
+  - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+  - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the *endpoints* subnet type creates a default route (0.0.0.0/0) from the Endpoint subnets to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Endpoint subnets.
+
+Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the *public* and *core\_network* subnet types to the firewall endpoints.
+
+```hcl
+module "egress_with_inspection_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  ipv4_network_definition = "10.0.0.0/8"
+
+  central_vpcs = {
+    central-egress-inspection = {
+      type       = "egress_with_inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        public    = { netmask = 28 }
+        endpoints = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "egress" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Ingress VPC
+
+Defining the type **ingress** will create specific VPC subnets and routing to create a central Ingress VPC. When defining the VPC subnets (attribute `subnets`) two keys are mandatory: **public** - to place the [Elastic Load Balancers](https://aws.amazon.com/elasticloadbalancing/) or your own ingress solution - and **core\_network** - to place the Core Network attachment ENIs -. You are free to create additional subnets, but default configuration and VPC routing won't be created on them.
+
+When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core\_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for both the **public** and **core\_network** subnet types:
+
+- Public subnets (*public*)
+  - `connect_to_igw`          = (Optional|bool) Determines if the default route (0.0.0.0/0) is created in the public subnets with destination the Internet gateway. Defaults to `true`.
+  - `map_public_ip_on_launch` = (Optional|bool) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default to `false`.
+- Core Network subnets (*core\_network*)
+  - `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `false`.
+  - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+  - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
+
+```hcl
+module "egress_with_inspection_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  ipv4_network_definition = "10.0.0.0/8"
+
+  central_vpcs = {
+    ingress = {
+      type       = "ingress"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        public = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "ingress" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Ingress VPC (with inspection)
+
+Defining the type **ingress\_with\_inspection** will create specific VPC subnets and routing to create a central Ingress VPC with subnets to add an inspection layer between the Internet gateway and the public subnets - to inspect ingress traffic. When defining the VPC subnets (attribute `subnets`) three keys are mandatory:
+
+- **endpoints** to place the [AWS Network Firewall](https://aws.amazon.com/network-firewall/) or [Gateway Load Balancer](https://aws.amazon.com/elasticloadbalancing/gateway-load-balancer/) endpoints.
+- **public** to place the [Elastic Load Balancers](https://aws.amazon.com/elasticloadbalancing/) or your own ingress solution.
+- **core\_network** to place the Core Network attachment ENIs.
+
+You are free to create additional subnets, but default configuration and VPC routing won't be created on them. When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core\_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for both the **public** and **core\_network** subnet types:
+
+- Public subnets (*public*)
+  - `connect_to_igw`          = (Optional|bool) Determines if the default route (0.0.0.0/0) is created in the public subnets with destination the Internet gateway. Defaults to `false`.
+  - `map_public_ip_on_launch` = (Optional|bool) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default to `false`.
+- Core Network subnets (*core\_network*)
+  - `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `false`.
+  - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+  - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
+
+Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the [Internet gateway](https://aws.amazon.com/blogs/aws/new-vpc-ingress-routing-simplifying-integration-of-third-party-appliances/) and *core\_network* subnet types to the firewall endpoints.
+
+```hcl
+module "egress_with_inspection_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  ipv4_network_definition = "10.0.0.0/8"
+
+  central_vpcs = {
+    ingress-with-inspection = {
+      type       = "ingress_with_inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { netmask = 28 }
+        public    = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "ingress" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Shared Services VPC
+
+Defining the type **shared\_services** will create specific VPC subnets and routing to create a central Shared Services VPC. When defining the VPC subnets (attribute `subnets`) the only mandatory key is **core\_network** - to place the Core Network attachment ENIs. When defining the subnets, the following attributes can be configured:
+
+- `cidrs`       = (Optional|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of VPC Availability Zones in `az_count`.
+- `netmask`     = (Optional|number) **Cannot set if `cidrs` is set.**. Netmask of VPC CIDR block to calculate for each subnet.
+- `name_prefix` = (Optional|string) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted.
+- `tags`        = (Optional|map(string)) Tags to set on the subnet and associated resources. For example, for the *core\_network* subnet type, these tags will be applied to the Core Network attachment.
+
+In addition, additional attributes can be configured for both the **core\_network** subnet type:
+
+- `appliance_mode_support`  = (Optional|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `false`.
+- `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
+- `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
+
+Regarding the VPC routing, a default route (0.0.0.0/0) poiting to the Core Network attachment will be created in any private subnet you create.
+
+```hcl
+module "egress_with_inspection_vpc" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  central_vpcs = {
+    shared-services = {
+      type       = "shared_services"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        vpc_endpoints = { netmask = 28 }
+        hybrid_dns    = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "shared" }
+        }
+      }
+    }
+  }
+}
+```
+
+## Common questions
+
+### How can I configure tags in the Core Network attachment?
+
+AWS Cloud WAN automates the association of an attachment to a specific segment, reducing the operational overhead specially in multi-Account environments. If you check how to define a [core network policy](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policies-json.html), you will see that the parameter **attachment-policies** is where you can define how to automate the associations. What can you use to define the attachment's association policy? You can use the Resource ID, Account ID, AWS Region, Attachment Type, and **Tags** - which is the common item to use.
+
+Now that we have explained the importance of tags when creating Core Network attachments, how can I create these tags using the module? As we use the following [VPC module](https://registry.terraform.io/modules/aws-ia/vpc/aws/latest) to create the central VPCs, the tags defined under the **core\_network** subnet type will be applied to the Core Network attachment.
+
+```hcl
+core_network = {
+  netmask = 28
+
+  tags = { domain = "segment" }
+}
+```
+
+### Should I create Central VPCs in the same module definition as the Core Network?
+
+This module has been created to be used once per AWS Region you are creating resources - only 1 provider can be configured. This means that, if you want to create Central VPCs in several AWS Regions, you should have 1 module definition per Region. What about the Global Network and Core Network? These resources are global, and they can be created using a provider definition from any Region - of course, where [Cloud WAN is available](https://docs.aws.amazon.com/network-manager/latest/cloudwan/what-is-cloudwan.html#cloudwan-available-regions). **Important to note that whatever Region you configure for the provider that creates the Cloud WAN resources, the [home region](https://docs.aws.amazon.com/network-manager/latest/cloudwan/what-is-cloudwan.html#cloudwan-home-region) will be US West (Oregon)**.
+
+Coming back to the question, our recommendation is to create the Global Network and Core Network in a different module definition than the Central VPCs - even if the provider you use to create the global resource is also used to create Central VPCs in that same Region. The main reason of the recommendation is to decouple the definition of global and regional resources. That said, if you want to use the same module definition to create global resources and central VPCs in the Region the provider has configured, the module will allow you to do it (and it's not an anti-pattern).
+
+### When do I need to create the *base\_policy*?
 
 You will see two attributes when defining the `var.core_network` variable are *base\_policy\_document* and *base\_policy\_regions*, used in the module to define the *base\_policy*, *base\_policy\_document*, and *base\_policy\_regions* attributes in the `aws_networkmanager_core_network` resource. But... why do we need the *base\_policy*?
 
@@ -163,6 +542,35 @@ You have two ways to define the *base\_policy*:
 * Step 1: Update and apply the policy document with the new AWS Region(s).
 * Step 2: Create the new attachment(s) and update the policy document if any static route is needed.
 
+## Troubleshooting
+
+### Error: creating Network Manager VPC Attachment: ValidationException: A live policy was not found
+
+If you are creating for the first time the Core Network and the Central VPCs using the module, you will get the following error:
+
+```
+Error: creating Network Manager VPC (arn:aws:ec2:XXXXXXX-X:XXXXXXX:vpc/vpc-XXXXXXX) Attachment (core-network-XXXXXXX): ValidationException: A live policy was not found
+```
+
+This error is thrown because when creating the Core Network two resources are created: `aws_networkmanager_core_network` (main resource) and `aws_networkmanager_core_network_policy_attachment` (policy attachment). When creating the VPC attachments, the first resource is the one reference so when it finishes to be created, Terraform will try to create the attachment without waiting for the policy to be LIVE - hence the error. *You won't experience this error if the central VPCs are defined in the same module definition as the Core Network.*
+
+How to avoid the error? You can do two things:
+
+- If you create the Core Network using this module, but in a separate definition, you can use the [target](https://developer.hashicorp.com/terraform/tutorials/state/resource-targeting) option to create first the Core Network policy attachment resource.
+- If you create the Core Network using directly the provider resources, you can use a [depends\_on](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) argument in the module definition to wait for the policy attachment to be created (LIVE) before start creating the central VPCs.
+
+### Creating Central VPCs with IPAM configuration - The "for\_each" map includes keys derived from resource attributes that cannot be determined until apply
+
+When creating Central VPCs referencing an IPAM pool ID, you get the following error:
+
+```
+The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.
+When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values.
+Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
+```
+
+As described in the error itself, you first need to create the IPAM pool to then later create the VPCs. You can use the [target](https://developer.hashicorp.com/terraform/tutorials/state/resource-targeting) option if the IPAM resources are created in the same document (and state file) as the VPCs.
+
 ## Requirements
 
 | Name | Version |
@@ -180,6 +588,7 @@ You have two ways to define the *base\_policy*:
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_central_vpcs"></a> [central\_vpcs](#module\_central\_vpcs) | aws-ia/vpc/aws | 4.4.1 |
 | <a name="module_core_network_tags"></a> [core\_network\_tags](#module\_core\_network\_tags) | aws-ia/label/aws | 0.0.5 |
 | <a name="module_global_network_tags"></a> [global\_network\_tags](#module\_global\_network\_tags) | aws-ia/label/aws | 0.0.5 |
 | <a name="module_tags"></a> [tags](#module\_tags) | aws-ia/label/aws | 0.0.5 |
@@ -199,16 +608,19 @@ You have two ways to define the *base\_policy*:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_core_network"></a> [core\_network](#input\_core\_network) | Core Network definition - providing information to this variable will create a new Core Network. Conflicts with `var.core_network_arn`.<br>This variable expects the following attributes:<br>- `description`                              = (Optional\|string) Core Network's description.<br>- `policy_document`                          = (Optional\|any) Core Network's policy in JSON format. It is recommended the use of the [Core Network Document data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document)<br>- `base_policy_document`                     = (Optional\|any) Conflicts with `base_policy_regions`. Sets the base policy document for the Core Network. For more information about the need of the base policy, check the README document.<br>- `base_policy_regions`                      = (Optional\|list(string)) Conflicts with `base_policy_document`. List of AWS Regions to create the base policy document in the Core Network. For more information about the need of the base policy, check the README document.<br>- `resource_share_name`                      = (Optional\|string) AWS Resource Access Manager (RAM) Resource Share name. Providing this value, RAM resources will be created to share the Core Network with the principals indicated in `var.core_network.ram_share_principals`.<br>- `resource_share_allow_external_principals` = (Optional\|bool) Indicates whether principals outside your AWS Organization can be associated with a Resource Share.<br>- `ram_share_principals`                     = (Optional\|list(string)) List of principals (AWS Account or AWS Organization) to share the Core Network with.<br>- `tags`                                     = (Optional\|map(string)) Tags to apply to the Core Network and RAM Resource Share (if created). | `any` | `{}` | no |
+| <a name="input_central_vpcs"></a> [central\_vpcs](#input\_central\_vpcs) | Central VPCs definition. This variable expects a map of VPCs. You can specify the following attributes:<br>- `type`                     = (string) VPC type (`inspection`, `egress`, `egress_with_inspection`, `ingress`, `ingress_with_inspection`, `shared_services`) - each one of them with a specific VPC routing. For more information about the configuration of each VPC type, check the README.<br>- `name`                     = (Optional\|string) Name of the VPC. If not defined, the key of the map will be used.<br>- `cidr_block`               = (Optional\|string) IPv4 CIDR range. **Cannot set if vpc\_ipv4\_ipam\_pool\_id is set.**<br>- `vpc_ipv4_ipam_pool_id`    = (Optional\|string) Set to use IPAM to get an IPv4 CIDR block.  **Cannot set if cidr\_block is set.**<br>- `vpc_ipv4_netmask_length`  = (Optional\|number) Set to use IPAM to get an IPv4 CIDR block using a specified netmask. Must be set with `var.vpc_ipv4_ipam_pool_id`.<br>- `az_count`                 = (number) Searches the number of AZs in the region and takes a slice based on this number - the slice is sorted a-z.<br>- `vpc_enable_dns_hostnames` = (Optional\|bool) Indicates whether the instances launched in the VPC get DNS hostnames. Enabled by default.<br>- `vpc_enable_dns_support`   = (Optional\|bool) Indicates whether the DNS resolution is supported for the VPC. If enabled, queries to the Amazon provided DNS server at the 169.254.169.253 IP address, or the reserved IP address at the base of the VPC network range "plus two" succeed. If disabled, the Amazon provided DNS service in the VPC that resolves public DNS hostnames to IP addresses is not enabled. Enabled by default.<br>- `vpc_instance_tenancy`     = (Optional\|string) The allowed tenancy of instances launched into the VPC.<br>- `vpc_flow_logs`            = (Optional\|object(any)) Configuration of the VPC Flow Logs of the VPC configured. Options: "cloudwatch", "s3", "none".<br>- `subnets`                  = (any) Configuration of the subnets to create in the VPC. Depending the VPC type, the format (subnets to configure and resources created by the module) will be different. Check the README for more information. <br>- `tags`                     = (Optional\|map(string)) Tags to apply to all the Central VPC resources. | `any` | `{}` | no |
+| <a name="input_core_network"></a> [core\_network](#input\_core\_network) | Core Network definition - providing information to this variable will create a new Core Network. Conflicts with `var.core_network_arn`.<br>This variable expects the following attributes:<br>- `description`                              = (string) Core Network's description.<br>- `policy_document`                          = (any) Core Network's policy in JSON format.<br>- `base_policy_document`                     = (Optional\|any) Conflicts with `base_policy_regions`. Sets the base policy document for the Core Network. For more information about the need of the base policy, check the README document.<br>- `base_policy_regions`                      = (Optional\|list(string)) Conflicts with `base_policy_document`. List of AWS Regions to create the base policy document in the Core Network. For more information about the need of the base policy, check the README document.<br>- `resource_share_name`                      = (Optional\|string) AWS Resource Access Manager (RAM) Resource Share name. Providing this value, RAM resources will be created to share the Core Network with the principals indicated in `var.core_network.ram_share_principals`.<br>- `resource_share_allow_external_principals` = (Optional\|bool) Indicates whether principals outside your AWS Organization can be associated with a Resource Share.<br>- `ram_share_principals`                     = (Optional\|list(string)) List of principals (AWS Account or AWS Organization) to share the Core Network with.<br>- `tags`                                     = (Optional\|map(string)) Tags to apply to the Core Network and RAM Resource Share (if created). | `any` | `{}` | no |
 | <a name="input_core_network_arn"></a> [core\_network\_arn](#input\_core\_network\_arn) | (Optional) Core Network ARN. Conflicts with `var.core_network`. | `string` | `null` | no |
-| <a name="input_global_network"></a> [global\_network](#input\_global\_network) | Global Network definition - providing information to this variable will create a new Global Network. Conflicts with `var.global_network_id`.<br>This variable expects the following attributes:<br>- `description` = (Optional\|string) Global Network's description.<br>- `tags`        = (Optional\|map(string)) Tags to apply to the Global Network.<pre></pre> | `any` | `{}` | no |
+| <a name="input_global_network"></a> [global\_network](#input\_global\_network) | Global Network definition - providing information to this variable will create a new Global Network. Conflicts with `var.global_network_id`.<br>This variable expects the following attributes:<br>- `description` = (string) Global Network's description.<br>- `tags`        = (Optional\|map(string)) Tags to apply to the Global Network.<pre></pre> | `any` | `{}` | no |
 | <a name="input_global_network_id"></a> [global\_network\_id](#input\_global\_network\_id) | (Optional) Global Network ID. Conflicts with `var.global_network`. | `string` | `null` | no |
+| <a name="input_ipv4_network_definition"></a> [ipv4\_network\_definition](#input\_ipv4\_network\_definition) | Definition of the IPv4 CIDR blocks of the AWS network - needed for the VPC routes in Ingress and Egress VPC types. You can specific either a CIDR range or a Prefix List ID. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Tags to apply to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_central_vpcs"></a> [central\_vpcs](#output\_central\_vpcs) | Central VPC information. Full output of VPC module - https://registry.terraform.io/modules/aws-ia/vpc/aws/latest. |
 | <a name="output_core_network"></a> [core\_network](#output\_core\_network) | Core Network. Full output of aws\_networkmanager\_core\_network. |
 | <a name="output_global_network"></a> [global\_network](#output\_global\_network) | Global Network. Full output of aws\_networkmanager\_global\_network. |
 | <a name="output_ram_resource_share"></a> [ram\_resource\_share](#output\_ram\_resource\_share) | Resource Access Manager (RAM) Resource Share. Full output of aws\_ram\_resource\_share. |

--- a/data.tf
+++ b/data.tf
@@ -9,9 +9,53 @@ locals {
   create_base_policy = (try(var.core_network.base_policy_document, null) == null) && (try(var.core_network.base_policy_regions, null) == null) ? false : true
   # RAM Resources
   create_ram_resources = try(var.core_network.resource_share_name, null) != null
+
+  # ---------- CENTRAL VPC - SUBNETS CONFIGURATION ----------
+  subnets = {
+    inspection = {
+      endpoints    = { name_prefix = "endpoints" }
+      core_network = { appliance_mode_support = true }
+    }
+    egress = {
+      public = { nat_gateway_configuration = "all_azs" }
+      core_network = {
+        appliance_mode_support  = false
+        connect_to_public_natgw = true
+      }
+    }
+    egress_with_inspection = {
+      public       = { nat_gateway_configuration = "all_azs" }
+      endpoints    = { connect_to_public_natgw = true }
+      core_network = { appliance_mode_support = true }
+    }
+    shared_services = {
+      core_network = { appliance_mode_support = false }
+    }
+    ingress = {
+      public       = { nat_gateway_configuration = "none" }
+      core_network = { appliance_mode_support = false }
+    }
+    ingress_with_inspection = {
+      endpoints = { name_prefix = "endpoints" }
+      public = {
+        nat_gateway_configuration = "none"
+        connect_to_igw            = false
+      }
+      core_network = { appliance_mode_support = false }
+    }
+  }
+
+  # ---------- CENTRAL VPC - CORE NETWORK ROUTES CONFIGURATION ----------
+  core_network_routes = {
+    inspection              = { endpoints = "0.0.0.0/0" }
+    egress                  = { public = var.ipv4_network_definition }
+    egress_with_inspection  = { endpoints = var.ipv4_network_definition }
+    ingress                 = { public = var.ipv4_network_definition }
+    ingress_with_inspection = { public = var.ipv4_network_definition }
+  }
 }
 
-# Sanitizes tags
+# ---------- SANITIZES TAGS ---------
 module "tags" {
   source  = "aws-ia/label/aws"
   version = "0.0.5"

--- a/examples/central_vpcs/.header.md
+++ b/examples/central_vpcs/.header.md
@@ -1,0 +1,10 @@
+# AWS Cloud WAN Module - Central VPCs example
+
+This example creates a Network Manager Global Network and Cloud WAN Core Network, with central VPCs (1 per each type).
+
+## Usage
+
+- Initialize Terraform using `terraform init`.
+- First create the Global Network and Core Network using `terraform apply -target="module.cloud_wan"`.
+- Now you can deploy the rest of the infrastructure using `terraform apply`.
+- To delete everything, use `terraform destroy`.

--- a/examples/central_vpcs/.terraform-docs.yaml
+++ b/examples/central_vpcs/.terraform-docs.yaml
@@ -1,0 +1,20 @@
+formatter: markdown
+header-from: .header.md
+settings:
+  anchor: true
+  color: true
+  default: true
+  escape: true
+  html: true
+  indent: 2
+  required: true
+  sensitive: true
+  type: true
+
+sort:
+  enabled: true
+  by: required
+
+output:
+  file: README.md
+  mode: replace

--- a/examples/central_vpcs/README.md
+++ b/examples/central_vpcs/README.md
@@ -1,0 +1,52 @@
+<!-- BEGIN_TF_DOCS -->
+# AWS Cloud WAN Module - Central VPCs example
+
+This example creates a Network Manager Global Network and Cloud WAN Core Network, with central VPCs (1 per each type).
+
+## Usage
+
+- Initialize Terraform using `terraform init`.
+- First create the Global Network and Core Network using `terraform apply -target="module.cloud_wan"`.
+- Now you can deploy the rest of the infrastructure using `terraform apply`.
+- To delete everything, use `terraform destroy`.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.21.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_cloud_wan"></a> [cloud\_wan](#module\_cloud\_wan) | ../.. | n/a |
+| <a name="module_cloudwan_central_vpcs"></a> [cloudwan\_central\_vpcs](#module\_cloudwan\_central\_vpcs) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_networkmanager_core_network_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region. | `string` | `"eu-west-1"` | no |
+| <a name="input_identifier"></a> [identifier](#input\_identifier) | Example identifier. | `string` | `"create-global-core-network"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_central_vpcs"></a> [central\_vpcs](#output\_central\_vpcs) | Central VPC IDs. |
+| <a name="output_cloud_wan"></a> [cloud\_wan](#output\_cloud\_wan) | AWS Cloud WAN resources. |
+<!-- END_TF_DOCS -->

--- a/examples/central_vpcs/main.tf
+++ b/examples/central_vpcs/main.tf
@@ -1,0 +1,162 @@
+# --- examples/central_vpcs/main.tf ---
+
+# AWS Cloud WAN module - Calling the module first time to create Global Network & Core Network
+module "cloud_wan" {
+  source = "../.."
+
+  global_network = {
+    description = "Global Network"
+
+    tags = {
+      Name = "global-network"
+    }
+  }
+
+  core_network = {
+    description     = "Core Network"
+    policy_document = data.aws_networkmanager_core_network_policy_document.policy.json
+
+    tags = {
+      Name = "core-network"
+    }
+  }
+}
+
+# AWS Cloud WAN module - Calling the module second time to create Central VPCs (all VPC types)
+module "cloudwan_central_vpcs" {
+  source = "../.."
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  ipv4_network_definition = "10.0.0.0/8"
+  central_vpcs = {
+    egress = {
+      type       = "egress"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        public = { cidrs = ["10.10.0.0/28", "10.10.0.16/28"] }
+        core_network = {
+          cidrs = ["10.10.0.32/28", "10.10.0.48/28"]
+
+          tags = { domain = "egress" }
+        }
+      }
+    }
+    egress-with-inspection = {
+      type       = "egress_with_inspection"
+      cidr_block = "10.10.1.0/24"
+      az_count   = 2
+
+      subnets = {
+        public    = { netmask = 28 }
+        endpoints = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "egress" }
+        }
+      }
+    }
+    shared-services = {
+      type       = "shared_services"
+      cidr_block = "10.10.2.0/24"
+      az_count   = 2
+
+      subnets = {
+        vpc_endpoints = { netmask = 28 }
+        hybrid_dns    = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "shared" }
+        }
+      }
+    }
+    inspection = {
+      type       = "inspection"
+      cidr_block = "10.10.3.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { cidrs = ["10.10.3.0/28", "10.10.3.16/28"] }
+        core_network = {
+          cidrs = ["10.10.3.32/28", "10.10.3.48/28"]
+
+          tags = { domain = "inspection" }
+        }
+      }
+    }
+    ingress = {
+      type       = "ingress"
+      cidr_block = "10.10.4.0/24"
+      az_count   = 2
+
+      subnets = {
+        public = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "ingress" }
+        }
+      }
+    }
+    ingress-with-inspection = {
+      type       = "ingress_with_inspection"
+      cidr_block = "10.10.5.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { netmask = 28 }
+        public    = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "ingress" }
+        }
+      }
+    }
+  }
+}
+
+# Core Network policy
+locals {
+  segments = ["egress", "ingress", "inspection", "shared"]
+}
+
+data "aws_networkmanager_core_network_policy_document" "policy" {
+  core_network_configuration {
+    vpn_ecmp_support = false
+    asn_ranges       = ["64515-64520"]
+    edge_locations {
+      location = var.aws_region
+    }
+  }
+
+  dynamic "segments" {
+    for_each = local.segments
+    iterator = segment
+
+    content {
+      name                          = segment.value
+      require_attachment_acceptance = false
+      isolate_attachments           = false
+    }
+  }
+
+  attachment_policies {
+    rule_number     = 100
+    condition_logic = "or"
+
+    conditions {
+      type = "tag-exists"
+      key  = "domain"
+    }
+
+    action {
+      association_method = "tag"
+      tag_value_of_key   = "domain"
+    }
+  }
+}

--- a/examples/central_vpcs/outputs.tf
+++ b/examples/central_vpcs/outputs.tf
@@ -1,0 +1,14 @@
+# --- examples/central_vpcs/outputs.tf ---
+
+output "cloud_wan" {
+  description = "AWS Cloud WAN resources."
+  value = {
+    global_network = module.cloud_wan.global_network.id
+    core_network   = module.cloud_wan.core_network.id
+  }
+}
+
+output "central_vpcs" {
+  description = "Central VPC IDs."
+  value       = { for k, v in module.cloudwan_central_vpcs.central_vpcs : k => v.vpc_attributes.id }
+}

--- a/examples/central_vpcs/providers.tf
+++ b/examples/central_vpcs/providers.tf
@@ -1,0 +1,15 @@
+# --- examples/central_vpcs/providers.tf ---
+
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.21.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/examples/central_vpcs/variables.tf
+++ b/examples/central_vpcs/variables.tf
@@ -1,0 +1,15 @@
+# --- examples/central_vpcs_egress_shared_services/variables.tf ---
+
+variable "identifier" {
+  type        = string
+  description = "Example identifier."
+
+  default = "create-global-core-network"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS Region."
+
+  default = "eu-west-1"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,25 @@
 # --- root/outputs.tf ---
 
-# GLOBAL NETORK (if created)
+# GLOBAL NETORK
 output "global_network" {
   value       = local.create_global_network ? aws_networkmanager_global_network.global_network[0] : null
   description = "Global Network. Full output of aws_networkmanager_global_network."
 }
 
-# CORE NETWORK (if created)
+# CORE NETWORK
 output "core_network" {
   value       = local.create_core_network ? aws_networkmanager_core_network.core_network[0] : null
   description = "Core Network. Full output of aws_networkmanager_core_network."
 }
 
-# RESOURCE SHARE (if created)
+# RESOURCE SHARE
 output "ram_resource_share" {
   value       = local.create_ram_resources ? aws_ram_resource_share.resource_share[0] : null
   description = "Resource Access Manager (RAM) Resource Share. Full output of aws_ram_resource_share."
+}
+
+# CENTRAL VPCS
+output "central_vpcs" {
+  value       = try(module.central_vpcs, null)
+  description = "Central VPC information. Full output of VPC module - https://registry.terraform.io/modules/aws-ia/vpc/aws/latest."
 }

--- a/tests/examples_central_vpcs.tftest.hcl
+++ b/tests/examples_central_vpcs.tftest.hcl
@@ -1,0 +1,19 @@
+run "core_network" {
+  command = apply
+
+  plan_options {
+    target = [module.cloud_wan]
+  }
+
+  module {
+    source = "./examples/central_vpcs"
+  }
+}
+
+run "validate" {
+  command = apply
+  module {
+    source = "./examples/central_vpcs"
+  }
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "global_network" {
   description = <<-EOF
     Global Network definition - providing information to this variable will create a new Global Network. Conflicts with `var.global_network_id`.
     This variable expects the following attributes:
-    - `description` = (Optional|string) Global Network's description.
+    - `description` = (string) Global Network's description.
     - `tags`        = (Optional|map(string)) Tags to apply to the Global Network.
     ```
 EOF
@@ -38,8 +38,8 @@ variable "core_network" {
   description = <<-EOF
     Core Network definition - providing information to this variable will create a new Core Network. Conflicts with `var.core_network_arn`.
     This variable expects the following attributes:
-    - `description`                              = (Optional|string) Core Network's description.
-    - `policy_document`                          = (Optional|any) Core Network's policy in JSON format. It is recommended the use of the [Core Network Document data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document)
+    - `description`                              = (string) Core Network's description.
+    - `policy_document`                          = (any) Core Network's policy in JSON format.
     - `base_policy_document`                     = (Optional|any) Conflicts with `base_policy_regions`. Sets the base policy document for the Core Network. For more information about the need of the base policy, check the README document.
     - `base_policy_regions`                      = (Optional|list(string)) Conflicts with `base_policy_document`. List of AWS Regions to create the base policy document in the Core Network. For more information about the need of the base policy, check the README document.
     - `resource_share_name`                      = (Optional|string) AWS Resource Access Manager (RAM) Resource Share name. Providing this value, RAM resources will be created to share the Core Network with the principals indicated in `var.core_network.ram_share_principals`.
@@ -63,6 +63,63 @@ EOF
       "tags"
     ])) == 0
   }
+}
+
+# ---------- CENTRAL VPCS ----------
+variable "central_vpcs" {
+  description = <<-EOF
+    Central VPCs definition. This variable expects a map of VPCs. You can specify the following attributes:
+    - `type`                     = (string) VPC type (`inspection`, `egress`, `egress_with_inspection`, `ingress`, `ingress_with_inspection`, `shared_services`) - each one of them with a specific VPC routing. For more information about the configuration of each VPC type, check the README.
+    - `name`                     = (Optional|string) Name of the VPC. If not defined, the key of the map will be used.
+    - `cidr_block`               = (Optional|string) IPv4 CIDR range. **Cannot set if vpc_ipv4_ipam_pool_id is set.**
+    - `vpc_ipv4_ipam_pool_id`    = (Optional|string) Set to use IPAM to get an IPv4 CIDR block.  **Cannot set if cidr_block is set.**
+    - `vpc_ipv4_netmask_length`  = (Optional|number) Set to use IPAM to get an IPv4 CIDR block using a specified netmask. Must be set with `var.vpc_ipv4_ipam_pool_id`.
+    - `az_count`                 = (number) Searches the number of AZs in the region and takes a slice based on this number - the slice is sorted a-z.
+    - `vpc_enable_dns_hostnames` = (Optional|bool) Indicates whether the instances launched in the VPC get DNS hostnames. Enabled by default.
+    - `vpc_enable_dns_support`   = (Optional|bool) Indicates whether the DNS resolution is supported for the VPC. If enabled, queries to the Amazon provided DNS server at the 169.254.169.253 IP address, or the reserved IP address at the base of the VPC network range "plus two" succeed. If disabled, the Amazon provided DNS service in the VPC that resolves public DNS hostnames to IP addresses is not enabled. Enabled by default.
+    - `vpc_instance_tenancy`     = (Optional|string) The allowed tenancy of instances launched into the VPC.
+    - `vpc_flow_logs`            = (Optional|object(any)) Configuration of the VPC Flow Logs of the VPC configured. Options: "cloudwatch", "s3", "none".
+    - `subnets`                  = (any) Configuration of the subnets to create in the VPC. Depending the VPC type, the format (subnets to configure and resources created by the module) will be different. Check the README for more information. 
+    - `tags`                     = (Optional|map(string)) Tags to apply to all the Central VPC resources.
+EOF
+  type        = any
+  default     = {}
+
+  # Key values for Central VPCs
+  validation {
+    error_message = "Valid key values for Central VPCs: \"type\", \"name\", \"cidr_block\", \"az_count\", \"vpc_ipv4_ipam_pool_id\", \"vpc_ipv4_netmask_length\", \"vpc_enable_dns_hostnames\", \"vpc_enable_dns_support\", \"vpc_instance_tenancy\", \"subnets\", \"tags\"."
+    condition = alltrue([
+      for vpc in try(var.central_vpcs, {}) : length(setsubtract(keys(vpc), [
+        "type",
+        "name",
+        "cidr_block",
+        "az_count",
+        "vpc_ipv4_ipam_pool_id",
+        "vpc_ipv4_netmask_length",
+        "vpc_enable_dns_hostnames",
+        "vpc_enable_dns_support",
+        "vpc_instance_tenancy",
+        "subnets",
+        "tags"
+      ])) == 0
+    ])
+  }
+
+  # Valid VPC types
+  validation {
+    error_message = "Central VPC type can only be: \"egress\", \"inspection\", \"inspection_egress\", \"shared_services\", \"ingress\", \"inspection_ingress\"."
+    condition = alltrue([
+      for vpc in try(var.central_vpcs, {}) : contains(["inspection", "egress", "egress_with_inspection", "shared_services", "ingress", "ingress_with_inspection"], vpc.type)
+    ])
+  }
+}
+
+# ---------- NETWORK DEFINITION (IPV4) ----------
+variable "ipv4_network_definition" {
+  type        = string
+  description = "Definition of the IPv4 CIDR blocks of the AWS network - needed for the VPC routes in Ingress and Egress VPC types. You can specific either a CIDR range or a Prefix List ID."
+
+  default = null
 }
 
 # ---------- TAGS ----------


### PR DESCRIPTION
* Adding variables `var.ipv4_network_definition` and `var.central_vpcs` to support the creation of central VPCs.
* Example and test file to check the creation of Central VPCs.
* README update.