### PR TITLE
Adding AWS Network Firewall support

### DIFF
--- a/.header.md
+++ b/.header.md
@@ -202,7 +202,7 @@ In addition, additional attributes can be configured for the **core_network** su
 - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
 - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, a default route (0.0.0.0/0) is created in the **endpoints** subnet type pointing to the Core Network attachment. Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the *core_network* subnet type to the firewall endpoints.
+Regarding the VPC routing, a default route (0.0.0.0/0) is created in the **endpoints** route tables pointing to the Core Network attachment.
 
 ```hcl
 module "inspection_vpc" {
@@ -252,7 +252,7 @@ In addition, additional attributes can be configured for both the **public** and
   - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
   - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the *core_network* subnet type creates a default route (0.0.0.0/0) from the Core Network subnets to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
+Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the **core_network** subnet type creates a default route (0.0.0.0/0) in the route tables to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network in the **public** route tables.
 
 ```hcl
 module "egress_vpc" {
@@ -309,9 +309,7 @@ In addition, additional attributes can be configured for the **public**, **endpo
   - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
   - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the *endpoints* subnet type creates a default route (0.0.0.0/0) from the Endpoint subnets to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Endpoint subnets. 
-
-Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the *public* and *core_network* subnet types to the firewall endpoints.
+Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the **endpoints** subnet type creates a default route (0.0.0.0/0) in the route tables to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the **endpoints** route tables. 
 
 ```hcl
 module "egress_with_inspection_vpc" {
@@ -363,7 +361,7 @@ In addition, additional attributes can be configured for both the **public** and
   - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
   - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
+Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network in the **public** route tables.
 
 ```hcl
 module "egress_with_inspection_vpc" {
@@ -393,7 +391,7 @@ module "egress_with_inspection_vpc" {
 }
 ```
 
-### Ingress VPC (with inspection)
+### Ingress VPC (with inspection)
 
 Defining the type **ingress_with_inspection** will create specific VPC subnets and routing to create a central Ingress VPC with subnets to add an inspection layer between the Internet gateway and the public subnets - to inspect ingress traffic. When defining the VPC subnets (attribute `subnets`) three keys are mandatory:
 
@@ -418,9 +416,7 @@ In addition, additional attributes can be configured for both the **public** and
   - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
   - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
-
-Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the [Internet gateway](https://aws.amazon.com/blogs/aws/new-vpc-ingress-routing-simplifying-integration-of-third-party-appliances/) and *core_network* subnet types to the firewall endpoints.
+Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network in the **public** route tables.
 
 ```hcl
 module "egress_with_inspection_vpc" {
@@ -451,7 +447,7 @@ module "egress_with_inspection_vpc" {
 }
 ```
 
-### Shared Services VPC
+### Shared Services VPC
 
 Defining the type **shared_services** will create specific VPC subnets and routing to create a central Shared Services VPC. When defining the VPC subnets (attribute `subnets`) the only mandatory key is **core_network** - to place the Core Network attachment ENIs. When defining the subnets, the following attributes can be configured:
 
@@ -466,7 +462,7 @@ In addition, additional attributes can be configured for both the **core_network
 - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
 - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, a default route (0.0.0.0/0) poiting to the Core Network attachment will be created in any private subnet you create.
+Regarding the VPC routing, a default route (0.0.0.0/0) poiting to the Core Network attachment will be created in any private route table you create.
 
 ```hcl
 module "egress_with_inspection_vpc" {
@@ -495,9 +491,197 @@ module "egress_with_inspection_vpc" {
 }
 ```
 
-## Common questions
+## AWS Network Firewall
 
-### How can I configure tags in the Core Network attachment?
+The variable `var.aws_network_firewall` allows the configuration of [AWS Network Firewall](https://aws.amazon.com/network-firewall/) resources in those central VPCs where inspection can be added - VPC types `inspection`, `egress_with_inspection` and `ingress_with_inspection`. As we use the following [AWS Network Firewall module](https://registry.terraform.io/modules/aws-ia/networkfirewall/aws/latest), the VPC routing pointing to the firewall endpoints is also abstracted.
+
+The variable expects a map containing the Network Firewall configuration to apply in each VPC. How do you make sure the Network Firewall resource (and VPC routing) is created in the corresponding central VPC? By using the same **key value** you used in `var.central_vpcs`. Each map definition expects the following attributes:
+
+- `name`                     = (string) Name of the AWS Network Firewall resource.
+- `description`              = (string) Description of the AWS Network Firewall resource.
+- `policy_arn`               = (string) ARN of the Network Firewall Policy.
+- `delete_protection`        = (Optional|bool) Indicates whether it is possible to delete the firewall. Defaults to `false`.
+- `policy_change_protection` = (Optional|bool) Indicates whether it is possible to change the firewall policy. Defaults to `false`.
+- `subnet_change_protection` = (Optional|bool) Indicates whether it is possible to change the associated subnet(s) after creation. Defaults to `false`.
+- `tags`                     = (Optional|map(string)) Tags to apply to the AWS Network Firewall resource.
+
+### Inspection VPC
+
+If you configure the creation of an AWS Network Firewall resource in an Inspection VPC (type `inspection`), the VPC routes created are the default ones (0.0.0.0/0) pointing to the firewall endpoints in the **core_network** route tables.
+
+```hcl
+module "cloudwan_central_vpcs" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  global_network = {
+    description = "Global Network"
+
+    tags = {
+      Name = "global-network"
+    }
+  }
+
+  core_network = {
+    description     = "Core Network"
+    base_policy_regions = [var.aws_region]
+    policy_document = data.aws_networkmanager_core_network_policy_document.policy.json
+
+    tags = {
+      Name = "core-network"
+    }
+  }
+
+  ipv4_network_definition = "10.0.0.0/8"
+  central_vpcs = {
+    inspection = {
+      type       = "inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "inspection" }
+        }
+      }
+    }
+  }
+
+  aws_network_firewall = {
+    inspection = {
+      name        = "anfw-inspection"
+      description = "AWS Network Firewall - East/West"
+      policy_arn  = aws_networkfirewall_firewall_policy.policy.arn
+    }
+  }
+}
+```
+
+### Egress VPC
+
+If you configure the creation of an AWS Network Firewall resource in an Egress VPC (type `egress_with_inspection`), the VPC routes created are:
+
+* Default route (0.0.0.0/0) pointing to the firewall endpoints in the **core_network** route tables.
+* CIDR blocks provided in `var.ipv4_network_definition` pointing to the firewall endpoints in the **public** route tables.
+
+```hcl
+module "cloudwan_central_vpcs" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  global_network = {
+    description = "Global Network"
+
+    tags = {
+      Name = "global-network"
+    }
+  }
+
+  core_network = {
+    description     = "Core Network"
+    base_policy_regions = [var.aws_region]
+    policy_document = data.aws_networkmanager_core_network_policy_document.policy.json
+
+    tags = {
+      Name = "core-network"
+    }
+  }
+
+  ipv4_network_definition = "10.0.0.0/8"
+  central_vpcs = {
+    egress-inspection = {
+      type       = "egress_with_inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        public    = { netmask = 28 }
+        endpoints = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "egress" }
+        }
+      }
+    }
+  }
+
+  aws_network_firewall = {
+    egress-inspection = {
+      name        = "anfw-egress-inspection"
+      description = "AWS Network Firewall - Egress"
+      policy_arn  = aws_networkfirewall_firewall_policy.policy.arn
+    }
+  }
+}
+```
+
+### Ingress VPC
+
+If you configure the creation of an AWS Network Firewall resource in an Ingress VPC (type `ingress_with_inspection`), the following resources are created:
+
+* VPC route table associated to the Internet gateway.
+* Public subnet CIDR blocks pointing to the firewall endpoints in the IGW route table.
+* Default route (0.0.0.0/0) pointing to the firewall endpoints in the **public** route tables.
+
+```hcl
+module "cloudwan_central_vpcs" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  global_network = {
+    description = "Global Network"
+
+    tags = {
+      Name = "global-network"
+    }
+  }
+
+  core_network = {
+    description     = "Core Network"
+    base_policy_regions = [var.aws_region]
+    policy_document = data.aws_networkmanager_core_network_policy_document.policy.json
+
+    tags = {
+      Name = "core-network"
+    }
+  }
+
+  ipv4_network_definition = "10.0.0.0/8"
+  central_vpcs = {
+    ingress-inspection = {
+      type       = "ingress_with_inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { netmask = 28 }
+        public    = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "ingress" }
+        }
+      }
+    }
+  }
+
+  aws_network_firewall = {
+    ingress-inspection = {
+      name        = "anfw-ingress-inspection"
+      description = "AWS Network Firewall - Ingress"
+      policy_arn  = aws_networkfirewall_firewall_policy.policy.arn
+    }
+  }
+}
+```
+
+## Common questions
+
+### How can I configure tags in the Core Network attachment?
 
 AWS Cloud WAN automates the association of an attachment to a specific segment, reducing the operational overhead specially in multi-Account environments. If you check how to define a [core network policy](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policies-json.html), you will see that the parameter **attachment-policies** is where you can define how to automate the associations. What can you use to define the attachment's association policy? You can use the Resource ID, Account ID, AWS Region, Attachment Type, and **Tags** - which is the common item to use.
 
@@ -553,11 +737,11 @@ If you are creating for the first time the Core Network and the Central VPCs usi
 Error: creating Network Manager VPC (arn:aws:ec2:XXXXXXX-X:XXXXXXX:vpc/vpc-XXXXXXX) Attachment (core-network-XXXXXXX): ValidationException: A live policy was not found
 ```
 
-This error is thrown because when creating the Core Network two resources are created: `aws_networkmanager_core_network` (main resource) and `aws_networkmanager_core_network_policy_attachment` (policy attachment). When creating the VPC attachments, the first resource is the one reference so when it finishes to be created, Terraform will try to create the attachment without waiting for the policy to be LIVE - hence the error. *You won't experience this error if the central VPCs are defined in the same module definition as the Core Network.*
+This error is thrown because when creating the Core Network two resources are created: `aws_networkmanager_core_network` (main resource) and `aws_networkmanager_core_network_policy_attachment` (policy attachment). When creating the VPC attachments, the first resource is the one reference so when it finishes to be created, Terraform will try to create the attachment without waiting for the policy to be LIVE - hence the error.
 
 How to avoid the error? You can do two things:
 
-- If you create the Core Network using this module, but in a separate definition, you can use the [target](https://developer.hashicorp.com/terraform/tutorials/state/resource-targeting) option to create first the Core Network policy attachment resource.
+- If you create the Core Network using this module, you can use the [target](https://developer.hashicorp.com/terraform/tutorials/state/resource-targeting) option to create first the Core Network policy attachment resource.
 - If you create the Core Network using directly the provider resources, you can use a [depends_on](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) argument in the module definition to wait for the policy attachment to be created (LIVE) before start creating the central VPCs.
 
 ### Creating Central VPCs with IPAM configuration - The "for_each" map includes keys derived from resource attributes that cannot be determined until apply

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ In addition, additional attributes can be configured for the **core\_network** s
 - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
 - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, a default route (0.0.0.0/0) is created in the **endpoints** subnet type pointing to the Core Network attachment. Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the *core\_network* subnet type to the firewall endpoints.
+Regarding the VPC routing, a default route (0.0.0.0/0) is created in the **endpoints** route tables pointing to the Core Network attachment.
 
 ```hcl
 module "inspection_vpc" {
@@ -251,7 +251,7 @@ In addition, additional attributes can be configured for both the **public** and
   - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
   - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the *core\_network* subnet type creates a default route (0.0.0.0/0) from the Core Network subnets to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
+Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the **core\_network** subnet type creates a default route (0.0.0.0/0) in the route tables to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network in the **public** route tables.
 
 ```hcl
 module "egress_vpc" {
@@ -308,9 +308,7 @@ In addition, additional attributes can be configured for the **public**, **endpo
   - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
   - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the *endpoints* subnet type creates a default route (0.0.0.0/0) from the Endpoint subnets to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Endpoint subnets.
-
-Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the *public* and *core\_network* subnet types to the firewall endpoints.
+Regarding the VPC routing, the default configuration of the `connect_to_public_natgw` attribute in the **endpoints** subnet type creates a default route (0.0.0.0/0) in the route tables to the NAT gateways. The CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the **endpoints** route tables.
 
 ```hcl
 module "egress_with_inspection_vpc" {
@@ -362,7 +360,7 @@ In addition, additional attributes can be configured for both the **public** and
   - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
   - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
+Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network in the **public** route tables.
 
 ```hcl
 module "egress_with_inspection_vpc" {
@@ -392,7 +390,7 @@ module "egress_with_inspection_vpc" {
 }
 ```
 
-### Ingress VPC (with inspection)
+### Ingress VPC (with inspection)
 
 Defining the type **ingress\_with\_inspection** will create specific VPC subnets and routing to create a central Ingress VPC with subnets to add an inspection layer between the Internet gateway and the public subnets - to inspect ingress traffic. When defining the VPC subnets (attribute `subnets`) three keys are mandatory:
 
@@ -417,9 +415,7 @@ In addition, additional attributes can be configured for both the **public** and
   - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
   - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network from the Public subnets.
-
-Outside of the module is the creation of routing related to the firewall solution created - VPC routes from the [Internet gateway](https://aws.amazon.com/blogs/aws/new-vpc-ingress-routing-simplifying-integration-of-third-party-appliances/) and *core\_network* subnet types to the firewall endpoints.
+Regarding the VPC routing, the CIDR block or Prefix List defined in `var.ipv4_network_definition` (required in this VPC type) will be used to create a VPC route to the Core Network in the **public** route tables.
 
 ```hcl
 module "egress_with_inspection_vpc" {
@@ -450,7 +446,7 @@ module "egress_with_inspection_vpc" {
 }
 ```
 
-### Shared Services VPC
+### Shared Services VPC
 
 Defining the type **shared\_services** will create specific VPC subnets and routing to create a central Shared Services VPC. When defining the VPC subnets (attribute `subnets`) the only mandatory key is **core\_network** - to place the Core Network attachment ENIs. When defining the subnets, the following attributes can be configured:
 
@@ -465,7 +461,7 @@ In addition, additional attributes can be configured for both the **core\_networ
 - `require_acceptance`      = (Optional|bool) Whether the core network VPC attachment requires acceptance or not. Defaults to `false`.
 - `accept_attachment`       = (Optional|bool) Whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.
 
-Regarding the VPC routing, a default route (0.0.0.0/0) poiting to the Core Network attachment will be created in any private subnet you create.
+Regarding the VPC routing, a default route (0.0.0.0/0) poiting to the Core Network attachment will be created in any private route table you create.
 
 ```hcl
 module "egress_with_inspection_vpc" {
@@ -494,9 +490,197 @@ module "egress_with_inspection_vpc" {
 }
 ```
 
-## Common questions
+## AWS Network Firewall
 
-### How can I configure tags in the Core Network attachment?
+The variable `var.aws_network_firewall` allows the configuration of [AWS Network Firewall](https://aws.amazon.com/network-firewall/) resources in those central VPCs where inspection can be added - VPC types `inspection`, `egress_with_inspection` and `ingress_with_inspection`. As we use the following [AWS Network Firewall module](https://registry.terraform.io/modules/aws-ia/networkfirewall/aws/latest), the VPC routing pointing to the firewall endpoints is also abstracted.
+
+The variable expects a map containing the Network Firewall configuration to apply in each VPC. How do you make sure the Network Firewall resource (and VPC routing) is created in the corresponding central VPC? By using the same **key value** you used in `var.central_vpcs`. Each map definition expects the following attributes:
+
+- `name`                     = (string) Name of the AWS Network Firewall resource.
+- `description`              = (string) Description of the AWS Network Firewall resource.
+- `policy_arn`               = (string) ARN of the Network Firewall Policy.
+- `delete_protection`        = (Optional|bool) Indicates whether it is possible to delete the firewall. Defaults to `false`.
+- `policy_change_protection` = (Optional|bool) Indicates whether it is possible to change the firewall policy. Defaults to `false`.
+- `subnet_change_protection` = (Optional|bool) Indicates whether it is possible to change the associated subnet(s) after creation. Defaults to `false`.
+- `tags`                     = (Optional|map(string)) Tags to apply to the AWS Network Firewall resource.
+
+### Inspection VPC
+
+If you configure the creation of an AWS Network Firewall resource in an Inspection VPC (type `inspection`), the VPC routes created are the default ones (0.0.0.0/0) pointing to the firewall endpoints in the **core\_network** route tables.
+
+```hcl
+module "cloudwan_central_vpcs" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  global_network = {
+    description = "Global Network"
+
+    tags = {
+      Name = "global-network"
+    }
+  }
+
+  core_network = {
+    description     = "Core Network"
+    base_policy_regions = [var.aws_region]
+    policy_document = data.aws_networkmanager_core_network_policy_document.policy.json
+
+    tags = {
+      Name = "core-network"
+    }
+  }
+
+  ipv4_network_definition = "10.0.0.0/8"
+  central_vpcs = {
+    inspection = {
+      type       = "inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "inspection" }
+        }
+      }
+    }
+  }
+
+  aws_network_firewall = {
+    inspection = {
+      name        = "anfw-inspection"
+      description = "AWS Network Firewall - East/West"
+      policy_arn  = aws_networkfirewall_firewall_policy.policy.arn
+    }
+  }
+}
+```
+
+### Egress VPC
+
+If you configure the creation of an AWS Network Firewall resource in an Egress VPC (type `egress_with_inspection`), the VPC routes created are:
+
+* Default route (0.0.0.0/0) pointing to the firewall endpoints in the **core\_network** route tables.
+* CIDR blocks provided in `var.ipv4_network_definition` pointing to the firewall endpoints in the **public** route tables.
+
+```hcl
+module "cloudwan_central_vpcs" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  global_network = {
+    description = "Global Network"
+
+    tags = {
+      Name = "global-network"
+    }
+  }
+
+  core_network = {
+    description     = "Core Network"
+    base_policy_regions = [var.aws_region]
+    policy_document = data.aws_networkmanager_core_network_policy_document.policy.json
+
+    tags = {
+      Name = "core-network"
+    }
+  }
+
+  ipv4_network_definition = "10.0.0.0/8"
+  central_vpcs = {
+    egress-inspection = {
+      type       = "egress_with_inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        public    = { netmask = 28 }
+        endpoints = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "egress" }
+        }
+      }
+    }
+  }
+
+  aws_network_firewall = {
+    egress-inspection = {
+      name        = "anfw-egress-inspection"
+      description = "AWS Network Firewall - Egress"
+      policy_arn  = aws_networkfirewall_firewall_policy.policy.arn
+    }
+  }
+}
+```
+
+### Ingress VPC
+
+If you configure the creation of an AWS Network Firewall resource in an Ingress VPC (type `ingress_with_inspection`), the following resources are created:
+
+* VPC route table associated to the Internet gateway.
+* Public subnet CIDR blocks pointing to the firewall endpoints in the IGW route table.
+* Default route (0.0.0.0/0) pointing to the firewall endpoints in the **public** route tables.
+
+```hcl
+module "cloudwan_central_vpcs" {
+  source  = "aws-ia/cloudwan/aws"
+  version = "3.x.x"
+
+  global_network = {
+    description = "Global Network"
+
+    tags = {
+      Name = "global-network"
+    }
+  }
+
+  core_network = {
+    description     = "Core Network"
+    base_policy_regions = [var.aws_region]
+    policy_document = data.aws_networkmanager_core_network_policy_document.policy.json
+
+    tags = {
+      Name = "core-network"
+    }
+  }
+
+  ipv4_network_definition = "10.0.0.0/8"
+  central_vpcs = {
+    ingress-inspection = {
+      type       = "ingress_with_inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { netmask = 28 }
+        public    = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "ingress" }
+        }
+      }
+    }
+  }
+
+  aws_network_firewall = {
+    ingress-inspection = {
+      name        = "anfw-ingress-inspection"
+      description = "AWS Network Firewall - Ingress"
+      policy_arn  = aws_networkfirewall_firewall_policy.policy.arn
+    }
+  }
+}
+```
+
+## Common questions
+
+### How can I configure tags in the Core Network attachment?
 
 AWS Cloud WAN automates the association of an attachment to a specific segment, reducing the operational overhead specially in multi-Account environments. If you check how to define a [core network policy](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policies-json.html), you will see that the parameter **attachment-policies** is where you can define how to automate the associations. What can you use to define the attachment's association policy? You can use the Resource ID, Account ID, AWS Region, Attachment Type, and **Tags** - which is the common item to use.
 
@@ -552,11 +736,11 @@ If you are creating for the first time the Core Network and the Central VPCs usi
 Error: creating Network Manager VPC (arn:aws:ec2:XXXXXXX-X:XXXXXXX:vpc/vpc-XXXXXXX) Attachment (core-network-XXXXXXX): ValidationException: A live policy was not found
 ```
 
-This error is thrown because when creating the Core Network two resources are created: `aws_networkmanager_core_network` (main resource) and `aws_networkmanager_core_network_policy_attachment` (policy attachment). When creating the VPC attachments, the first resource is the one reference so when it finishes to be created, Terraform will try to create the attachment without waiting for the policy to be LIVE - hence the error. *You won't experience this error if the central VPCs are defined in the same module definition as the Core Network.*
+This error is thrown because when creating the Core Network two resources are created: `aws_networkmanager_core_network` (main resource) and `aws_networkmanager_core_network_policy_attachment` (policy attachment). When creating the VPC attachments, the first resource is the one reference so when it finishes to be created, Terraform will try to create the attachment without waiting for the policy to be LIVE - hence the error.
 
 How to avoid the error? You can do two things:
 
-- If you create the Core Network using this module, but in a separate definition, you can use the [target](https://developer.hashicorp.com/terraform/tutorials/state/resource-targeting) option to create first the Core Network policy attachment resource.
+- If you create the Core Network using this module, you can use the [target](https://developer.hashicorp.com/terraform/tutorials/state/resource-targeting) option to create first the Core Network policy attachment resource.
 - If you create the Core Network using directly the provider resources, you can use a [depends\_on](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) argument in the module definition to wait for the policy attachment to be created (LIVE) before start creating the central VPCs.
 
 ### Creating Central VPCs with IPAM configuration - The "for\_each" map includes keys derived from resource attributes that cannot be determined until apply
@@ -591,6 +775,8 @@ As described in the error itself, you first need to create the IPAM pool to then
 | <a name="module_central_vpcs"></a> [central\_vpcs](#module\_central\_vpcs) | aws-ia/vpc/aws | 4.4.1 |
 | <a name="module_core_network_tags"></a> [core\_network\_tags](#module\_core\_network\_tags) | aws-ia/label/aws | 0.0.5 |
 | <a name="module_global_network_tags"></a> [global\_network\_tags](#module\_global\_network\_tags) | aws-ia/label/aws | 0.0.5 |
+| <a name="module_network_firewall"></a> [network\_firewall](#module\_network\_firewall) | aws-ia/networkfirewall/aws | 1.0.0 |
+| <a name="module_public_subnet_cidrs"></a> [public\_subnet\_cidrs](#module\_public\_subnet\_cidrs) | ./modules/subnet_cidrs | n/a |
 | <a name="module_tags"></a> [tags](#module\_tags) | aws-ia/label/aws | 0.0.5 |
 
 ## Resources
@@ -603,15 +789,19 @@ As described in the error itself, you first need to create the IPAM pool to then
 | [aws_ram_principal_association.principal_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_principal_association) | resource |
 | [aws_ram_resource_association.resource_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_association) | resource |
 | [aws_ram_resource_share.resource_share](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share) | resource |
+| [aws_route_table.igw_route_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table_association.igw_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_prefix_list.ipv4_network_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/prefix_list) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_network_firewall"></a> [aws\_network\_firewall](#input\_aws\_network\_firewall) | AWS Network Firewall configuration. This variable expect a map of Network Firewall definitions to create a firewall resource (and corresponding VPC routing to firewall endpoints) in the corresponding VPC. The central VPC to create the resources is specified by using the same map key as in var.central\_vpcs. Resources will be created only in VPC types `inspection`, `egress_with_inspection`, and `ingress_with_inspection`.<br>Each map item expects the following attributes:<br>- `name`                     = (string) Name of the AWS Network Firewall resource.<br>- `description`              = (string) Description of the AWS Network Firewall resource.<br>- `policy_arn`               = (string) ARN of the Network Firewall Policy.<br>- `delete_protection`        = (Optional\|bool) Indicates whether it is possible to delete the firewall. Defaults to `false`.<br>- `policy_change_protection` = (Optional\|bool) Indicates whether it is possible to change the firewall policy. Defaults to `false`.<br>- `subnet_change_protection` = (Optional\|bool) Indicates whether it is possible to change the associated subnet(s) after creation. Defaults to `false`.<br>- `tags`                     = (Optional\|map(string)) Tags to apply to the AWS Network Firewall resource. | `any` | `{}` | no |
 | <a name="input_central_vpcs"></a> [central\_vpcs](#input\_central\_vpcs) | Central VPCs definition. This variable expects a map of VPCs. You can specify the following attributes:<br>- `type`                     = (string) VPC type (`inspection`, `egress`, `egress_with_inspection`, `ingress`, `ingress_with_inspection`, `shared_services`) - each one of them with a specific VPC routing. For more information about the configuration of each VPC type, check the README.<br>- `name`                     = (Optional\|string) Name of the VPC. If not defined, the key of the map will be used.<br>- `cidr_block`               = (Optional\|string) IPv4 CIDR range. **Cannot set if vpc\_ipv4\_ipam\_pool\_id is set.**<br>- `vpc_ipv4_ipam_pool_id`    = (Optional\|string) Set to use IPAM to get an IPv4 CIDR block.  **Cannot set if cidr\_block is set.**<br>- `vpc_ipv4_netmask_length`  = (Optional\|number) Set to use IPAM to get an IPv4 CIDR block using a specified netmask. Must be set with `var.vpc_ipv4_ipam_pool_id`.<br>- `az_count`                 = (number) Searches the number of AZs in the region and takes a slice based on this number - the slice is sorted a-z.<br>- `vpc_enable_dns_hostnames` = (Optional\|bool) Indicates whether the instances launched in the VPC get DNS hostnames. Enabled by default.<br>- `vpc_enable_dns_support`   = (Optional\|bool) Indicates whether the DNS resolution is supported for the VPC. If enabled, queries to the Amazon provided DNS server at the 169.254.169.253 IP address, or the reserved IP address at the base of the VPC network range "plus two" succeed. If disabled, the Amazon provided DNS service in the VPC that resolves public DNS hostnames to IP addresses is not enabled. Enabled by default.<br>- `vpc_instance_tenancy`     = (Optional\|string) The allowed tenancy of instances launched into the VPC.<br>- `vpc_flow_logs`            = (Optional\|object(any)) Configuration of the VPC Flow Logs of the VPC configured. Options: "cloudwatch", "s3", "none".<br>- `subnets`                  = (any) Configuration of the subnets to create in the VPC. Depending the VPC type, the format (subnets to configure and resources created by the module) will be different. Check the README for more information. <br>- `tags`                     = (Optional\|map(string)) Tags to apply to all the Central VPC resources. | `any` | `{}` | no |
 | <a name="input_core_network"></a> [core\_network](#input\_core\_network) | Core Network definition - providing information to this variable will create a new Core Network. Conflicts with `var.core_network_arn`.<br>This variable expects the following attributes:<br>- `description`                              = (string) Core Network's description.<br>- `policy_document`                          = (any) Core Network's policy in JSON format.<br>- `base_policy_document`                     = (Optional\|any) Conflicts with `base_policy_regions`. Sets the base policy document for the Core Network. For more information about the need of the base policy, check the README document.<br>- `base_policy_regions`                      = (Optional\|list(string)) Conflicts with `base_policy_document`. List of AWS Regions to create the base policy document in the Core Network. For more information about the need of the base policy, check the README document.<br>- `resource_share_name`                      = (Optional\|string) AWS Resource Access Manager (RAM) Resource Share name. Providing this value, RAM resources will be created to share the Core Network with the principals indicated in `var.core_network.ram_share_principals`.<br>- `resource_share_allow_external_principals` = (Optional\|bool) Indicates whether principals outside your AWS Organization can be associated with a Resource Share.<br>- `ram_share_principals`                     = (Optional\|list(string)) List of principals (AWS Account or AWS Organization) to share the Core Network with.<br>- `tags`                                     = (Optional\|map(string)) Tags to apply to the Core Network and RAM Resource Share (if created). | `any` | `{}` | no |
 | <a name="input_core_network_arn"></a> [core\_network\_arn](#input\_core\_network\_arn) | (Optional) Core Network ARN. Conflicts with `var.core_network`. | `string` | `null` | no |
-| <a name="input_global_network"></a> [global\_network](#input\_global\_network) | Global Network definition - providing information to this variable will create a new Global Network. Conflicts with `var.global_network_id`.<br>This variable expects the following attributes:<br>- `description` = (string) Global Network's description.<br>- `tags`        = (Optional\|map(string)) Tags to apply to the Global Network.<pre></pre> | `any` | `{}` | no |
+| <a name="input_global_network"></a> [global\_network](#input\_global\_network) | Global Network definition - providing information to this variable will create a new Global Network. Conflicts with `var.global_network_id`.<br>This variable expects the following attributes:<br>- `description` = (string) Global Network's description.<br>- `tags`        = (Optional\|map(string)) Tags to apply to the Global Network. | `any` | `{}` | no |
 | <a name="input_global_network_id"></a> [global\_network\_id](#input\_global\_network\_id) | (Optional) Global Network ID. Conflicts with `var.global_network`. | `string` | `null` | no |
 | <a name="input_ipv4_network_definition"></a> [ipv4\_network\_definition](#input\_ipv4\_network\_definition) | Definition of the IPv4 CIDR blocks of the AWS network - needed for the VPC routes in Ingress and Egress VPC types. You can specific either a CIDR range or a Prefix List ID. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Tags to apply to all resources. | `map(string)` | `{}` | no |
@@ -620,6 +810,7 @@ As described in the error itself, you first need to create the IPAM pool to then
 
 | Name | Description |
 |------|-------------|
+| <a name="output_aws_network_firewall"></a> [aws\_network\_firewall](#output\_aws\_network\_firewall) | AWS Network Firewall. Full output of aws\_networkfirewall\_firewall. |
 | <a name="output_central_vpcs"></a> [central\_vpcs](#output\_central\_vpcs) | Central VPC information. Full output of VPC module - https://registry.terraform.io/modules/aws-ia/vpc/aws/latest. |
 | <a name="output_core_network"></a> [core\_network](#output\_core\_network) | Core Network. Full output of aws\_networkmanager\_core\_network. |
 | <a name="output_global_network"></a> [global\_network](#output\_global\_network) | Global Network. Full output of aws\_networkmanager\_global\_network. |

--- a/examples/central_vpcs_inspection/.header.md
+++ b/examples/central_vpcs_inspection/.header.md
@@ -1,0 +1,10 @@
+# AWS Cloud WAN Module - Central VPCs (with Inspection) example
+
+This example creates a Network Manager Global Network and Cloud WAN Core Network, with central VPCs (types *inspection*, *egress_with_inspection*, and *ingress_with_inspection*). AWS Network Firewall resource (and VPC routing) is created in each central VPC.
+
+## Usage
+
+- Initialize Terraform using `terraform init`.
+- First create the Global Network and Core Network using `terraform apply -target="module.cloud_wan"`.
+- Now you can deploy the rest of the infrastructure using `terraform apply`.
+- To delete everything, use `terraform destroy`.

--- a/examples/central_vpcs_inspection/.terraform-docs.yaml
+++ b/examples/central_vpcs_inspection/.terraform-docs.yaml
@@ -1,0 +1,20 @@
+formatter: markdown
+header-from: .header.md
+settings:
+  anchor: true
+  color: true
+  default: true
+  escape: true
+  html: true
+  indent: 2
+  required: true
+  sensitive: true
+  type: true
+
+sort:
+  enabled: true
+  by: required
+
+output:
+  file: README.md
+  mode: replace

--- a/examples/central_vpcs_inspection/README.md
+++ b/examples/central_vpcs_inspection/README.md
@@ -1,0 +1,62 @@
+<!-- BEGIN_TF_DOCS -->
+# AWS Cloud WAN Module - Central VPCs (with Inspection) example
+
+This example creates a Network Manager Global Network and Cloud WAN Core Network, with central VPCs (types *inspection*, *egress\_with\_inspection*, and *ingress\_with\_inspection*). AWS Network Firewall resource (and VPC routing) is created in each central VPC.
+
+## Usage
+
+- Initialize Terraform using `terraform init`.
+- First create the Global Network and Core Network using `terraform apply -target="module.cloud_wan"`.
+- Now you can deploy the rest of the infrastructure using `terraform apply`.
+- To delete everything, use `terraform destroy`.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.21.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_cloud_wan"></a> [cloud\_wan](#module\_cloud\_wan) | ../.. | n/a |
+| <a name="module_cloudwan_central_vpcs"></a> [cloudwan\_central\_vpcs](#module\_cloudwan\_central\_vpcs) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_networkfirewall_firewall_policy.egress_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy) | resource |
+| [aws_networkfirewall_firewall_policy.ingress_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy) | resource |
+| [aws_networkfirewall_firewall_policy.inspection_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy) | resource |
+| [aws_networkfirewall_rule_group.allow_domains](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group) | resource |
+| [aws_networkfirewall_rule_group.allow_east_west_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group) | resource |
+| [aws_networkfirewall_rule_group.allow_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group) | resource |
+| [aws_networkfirewall_rule_group.drop_remote](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group) | resource |
+| [aws_networkmanager_core_network_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document) | data source |
+| [http_http.myip](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region. | `string` | `"eu-west-1"` | no |
+| <a name="input_identifier"></a> [identifier](#input\_identifier) | Example identifier. | `string` | `"central-vpcs-inspection"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_network_firewall"></a> [aws\_network\_firewall](#output\_aws\_network\_firewall) | AWS Network Firewall IDs. |
+| <a name="output_central_vpcs"></a> [central\_vpcs](#output\_central\_vpcs) | Central VPC IDs. |
+| <a name="output_cloud_wan"></a> [cloud\_wan](#output\_cloud\_wan) | AWS Cloud WAN resources. |
+<!-- END_TF_DOCS -->

--- a/examples/central_vpcs_inspection/firewall_policy.tf
+++ b/examples/central_vpcs_inspection/firewall_policy.tf
@@ -1,0 +1,202 @@
+# --- examples/central_vpcs_inspection/firewall_policy.tf ---
+
+# ---------- NETWORK FIREWALL POLICY ----------
+# Firewall policy - East/West traffic
+resource "aws_networkfirewall_firewall_policy" "inspection_policy" {
+  name = "central-firewall-policy-${var.identifier}"
+
+  firewall_policy {
+    # Stateless configuration
+    stateless_default_actions          = ["aws:forward_to_sfe"]
+    stateless_fragment_default_actions = ["aws:forward_to_sfe"]
+
+    stateless_rule_group_reference {
+      priority     = 10
+      resource_arn = aws_networkfirewall_rule_group.drop_remote.arn
+    }
+
+    # Stateful configuration
+    stateful_engine_options {
+      rule_order = "STRICT_ORDER"
+    }
+    stateful_default_actions = ["aws:drop_strict", "aws:alert_strict"]
+    stateful_rule_group_reference {
+      priority     = 10
+      resource_arn = aws_networkfirewall_rule_group.allow_domains.arn
+    }
+  }
+}
+
+# Firewall policy - Egress traffic
+resource "aws_networkfirewall_firewall_policy" "egress_policy" {
+  name = "egress-firewall-policy-${var.identifier}"
+
+  firewall_policy {
+    # Stateless configuration
+    stateless_default_actions          = ["aws:forward_to_sfe"]
+    stateless_fragment_default_actions = ["aws:forward_to_sfe"]
+
+    stateless_rule_group_reference {
+      priority     = 10
+      resource_arn = aws_networkfirewall_rule_group.drop_remote.arn
+    }
+
+    # Stateful configuration
+    stateful_engine_options {
+      rule_order = "STRICT_ORDER"
+    }
+    stateful_default_actions = ["aws:drop_strict", "aws:alert_strict"]
+    stateful_rule_group_reference {
+      priority     = 10
+      resource_arn = aws_networkfirewall_rule_group.allow_domains.arn
+    }
+  }
+}
+
+# Firewall policy - Ingress traffic
+resource "aws_networkfirewall_firewall_policy" "ingress_policy" {
+  name = "ingress-firewall-policy-${var.identifier}"
+
+  firewall_policy {
+    # Stateless configuration
+    stateless_default_actions          = ["aws:forward_to_sfe"]
+    stateless_fragment_default_actions = ["aws:forward_to_sfe"]
+
+    stateless_rule_group_reference {
+      priority     = 10
+      resource_arn = aws_networkfirewall_rule_group.drop_remote.arn
+    }
+
+    # Stateful configuration
+    stateful_engine_options {
+      rule_order = "STRICT_ORDER"
+    }
+    stateful_default_actions = ["aws:drop_strict", "aws:alert_strict"]
+    stateful_rule_group_reference {
+      priority     = 10
+      resource_arn = aws_networkfirewall_rule_group.allow_domains.arn
+    }
+  }
+}
+
+# Stateless Rule Group - Dropping SSH traffic
+resource "aws_networkfirewall_rule_group" "drop_remote" {
+  capacity = 2
+  name     = "drop-remote-${var.identifier}"
+  type     = "STATELESS"
+  rule_group {
+    rules_source {
+      stateless_rules_and_custom_actions {
+
+        stateless_rule {
+          priority = 1
+          rule_definition {
+            actions = ["aws:drop"]
+            match_attributes {
+              protocols = [6]
+              source {
+                address_definition = "0.0.0.0/0"
+              }
+              source_port {
+                from_port = 0
+                to_port   = 65535
+              }
+              destination {
+                address_definition = "0.0.0.0/0"
+              }
+              destination_port {
+                from_port = 22
+                to_port   = 22
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+# Stateful Rule Group - Allowing access to .amazon.com (HTTPS)
+resource "aws_networkfirewall_rule_group" "allow_domains" {
+  capacity = 100
+  name     = "allow-domains-${var.identifier}"
+  type     = "STATEFUL"
+  rule_group {
+    rules_source {
+      rules_string = <<EOF
+      pass tcp any any <> $EXTERNAL_NET 443 (msg:"Allowing TCP in port 443"; flow:not_established; sid:892123; rev:1;)
+      pass tls any any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".amazon.com"; endswith; msg:"Allowing .amazon.com HTTPS requests"; sid:892125; rev:1;)
+      EOF
+    }
+    stateful_rule_options {
+      rule_order = "STRICT_ORDER"
+    }
+  }
+}
+
+# Stateful Rule Group - Allowing HTTPS connections between VPCs within the network
+resource "aws_networkfirewall_rule_group" "allow_east_west_https" {
+  capacity = 100
+  name     = "allow-east-west-${var.identifier}"
+  type     = "STATEFUL"
+  rule_group {
+    rule_variables {
+      ip_sets {
+        key = "SUPERNET"
+        ip_set {
+          definition = ["10.0.0.0/8"]
+        }
+      }
+    }
+    rules_source {
+      rules_string = <<EOF
+      pass tcp $SUPERNET any <> $SUPERNET 443 (msg:"Allowing TCP in port 443"; flow:not_established; sid:892123; rev:1;)
+      pass tls $SUPERNET any -> $SUPERNET 443 (msg:"Allowing HTTPS requests"; sid:892125; rev:1;)
+      EOF
+    }
+    stateful_rule_options {
+      rule_order = "STRICT_ORDER"
+    }
+  }
+}
+
+# Stateful Rule Group - Allowing access to .amazon.com (HTTPS)
+resource "aws_networkfirewall_rule_group" "allow_ingress" {
+  capacity = 100
+  name     = "allow-ingress-${var.identifier}"
+  type     = "STATEFUL"
+  rule_group {
+    rules_source {
+      stateful_rule {
+        action = "PASS"
+        header {
+          destination      = "ANY"
+          destination_port = "ANY"
+          protocol         = "HTTP"
+          direction        = "ANY"
+          source_port      = "ANY"
+          source           = local.ifconfig_co_json.ip
+        }
+        rule_option {
+          keyword  = "sid"
+          settings = ["1"]
+        }
+      }
+    }
+    stateful_rule_options {
+      rule_order = "STRICT_ORDER"
+    }
+  }
+}
+
+# My IP - for testing purposes
+data "http" "myip" {
+  url = "https://ifconfig.co/json"
+  request_headers = {
+    Accept = "application/json"
+  }
+}
+
+locals {
+  ifconfig_co_json = jsondecode(data.http.myip.response_body)
+}

--- a/examples/central_vpcs_inspection/main.tf
+++ b/examples/central_vpcs_inspection/main.tf
@@ -1,0 +1,138 @@
+# --- examples/central_vpcs_inspection/main.tf ---
+
+# AWS Cloud WAN module - Calling the module first time to create Global Network & Core Network
+module "cloud_wan" {
+  source = "../.."
+
+  global_network = {
+    description = "Global Network"
+
+    tags = {
+      Name = "global-network"
+    }
+  }
+
+  core_network = {
+    description         = "Core Network"
+    base_policy_regions = [var.aws_region]
+    policy_document     = data.aws_networkmanager_core_network_policy_document.policy.json
+
+    tags = {
+      Name = "core-network"
+    }
+  }
+}
+
+# AWS Cloud WAN module - Global Network, Core Network, and Central VPCs (with inspection)
+module "cloudwan_central_vpcs" {
+  source = "../.."
+
+  core_network_arn = module.cloud_wan.core_network.arn
+
+  ipv4_network_definition = "10.0.0.0/8"
+  central_vpcs = {
+    inspection = {
+      type       = "inspection"
+      cidr_block = "10.10.0.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "inspection" }
+        }
+      }
+    }
+    egress-inspection = {
+      type       = "egress_with_inspection"
+      cidr_block = "10.10.2.0/24"
+      az_count   = 2
+
+      subnets = {
+        public    = { netmask = 28 }
+        endpoints = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "egress" }
+        }
+      }
+    }
+    ingress-inspection = {
+      type       = "ingress_with_inspection"
+      cidr_block = "10.10.2.0/24"
+      az_count   = 2
+
+      subnets = {
+        endpoints = { netmask = 28 }
+        public    = { netmask = 28 }
+        core_network = {
+          netmask = 28
+
+          tags = { domain = "ingress" }
+        }
+      }
+    }
+  }
+
+  aws_network_firewall = {
+    inspection = {
+      name        = "anfw-inspection"
+      description = "AWS Network Firewall - East/West"
+      policy_arn  = aws_networkfirewall_firewall_policy.inspection_policy.arn
+    }
+    egress-inspection = {
+      name        = "anfw-egress-inspection"
+      description = "AWS Network Firewall - Egress"
+      policy_arn  = aws_networkfirewall_firewall_policy.egress_policy.arn
+    }
+    ingress-inspection = {
+      name        = "anfw-ingress-inspection"
+      description = "AWS Network Firewall - Ingress"
+      policy_arn  = aws_networkfirewall_firewall_policy.ingress_policy.arn
+    }
+  }
+}
+
+# Core Network policy
+locals {
+  segments = ["prod", "inspection", "egress", "ingress"]
+}
+
+data "aws_networkmanager_core_network_policy_document" "policy" {
+  core_network_configuration {
+    vpn_ecmp_support = false
+    asn_ranges       = ["64515-64520"]
+    edge_locations {
+      location = var.aws_region
+    }
+  }
+
+  dynamic "segments" {
+    for_each = local.segments
+    iterator = segment
+
+    content {
+      name                          = segment.value
+      require_attachment_acceptance = false
+      isolate_attachments           = false
+    }
+  }
+
+  attachment_policies {
+    rule_number     = 100
+    condition_logic = "or"
+
+    conditions {
+      type = "tag-exists"
+      key  = "domain"
+    }
+
+    action {
+      association_method = "tag"
+      tag_value_of_key   = "domain"
+    }
+  }
+}

--- a/examples/central_vpcs_inspection/outputs.tf
+++ b/examples/central_vpcs_inspection/outputs.tf
@@ -1,0 +1,19 @@
+# --- examples/central_vpcs_inspection/outputs.tf ---
+
+output "cloud_wan" {
+  description = "AWS Cloud WAN resources."
+  value = {
+    global_network = module.cloud_wan.global_network.id
+    core_network   = module.cloud_wan.core_network.id
+  }
+}
+
+output "central_vpcs" {
+  description = "Central VPC IDs."
+  value       = { for k, v in module.cloudwan_central_vpcs.central_vpcs : k => v.vpc_attributes.id }
+}
+
+output "aws_network_firewall" {
+  description = "AWS Network Firewall IDs."
+  value       = { for k, v in module.cloudwan_central_vpcs.aws_network_firewall : k => v.id }
+}

--- a/examples/central_vpcs_inspection/providers.tf
+++ b/examples/central_vpcs_inspection/providers.tf
@@ -1,0 +1,15 @@
+# --- examples/central_vpcs/providers.tf ---
+
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.21.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/examples/central_vpcs_inspection/variables.tf
+++ b/examples/central_vpcs_inspection/variables.tf
@@ -1,0 +1,15 @@
+# --- examples/central_vpcs_inspection/variables.tf ---
+
+variable "identifier" {
+  type        = string
+  description = "Example identifier."
+
+  default = "central-vpcs-inspection"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS Region."
+
+  default = "eu-west-1"
+}

--- a/modules/subnet_cidrs/main.tf
+++ b/modules/subnet_cidrs/main.tf
@@ -1,0 +1,14 @@
+# --- modules/subnet_cidrs/main.tf ---
+
+locals {
+  # List of Availability Zone IDs from map
+  azs = keys(var.subnet_ids)
+  # List of Subnet IDs from map
+  subnet_ids = values(var.subnet_ids)
+}
+
+data "aws_subnet" "subnet" {
+  count = var.number_azs
+
+  id = local.subnet_ids[count.index]
+}

--- a/modules/subnet_cidrs/outputs.tf
+++ b/modules/subnet_cidrs/outputs.tf
@@ -1,0 +1,6 @@
+# --- modules/subnet_cidrs/outputs.tf ---
+
+output "subnet_cidrs" {
+  description = "VPC subnet CIDRs."
+  value       = zipmap(local.azs, data.aws_subnet.subnet[*].cidr_block)
+}

--- a/modules/subnet_cidrs/providers.tf
+++ b/modules/subnet_cidrs/providers.tf
@@ -1,0 +1,11 @@
+# --- modules/subnet_cidrs/providers.tf ---
+
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.21.0"
+    }
+  }
+}

--- a/modules/subnet_cidrs/variables.tf
+++ b/modules/subnet_cidrs/variables.tf
@@ -1,0 +1,11 @@
+# --- modules/subnet_cidrs/variables.tf ---
+
+variable "subnet_ids" {
+  description = "VPC subnet IDs."
+  type        = map(string)
+}
+
+variable "number_azs" {
+  description = "Number of AZs in the VPC."
+  type        = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,3 +23,9 @@ output "central_vpcs" {
   value       = try(module.central_vpcs, null)
   description = "Central VPC information. Full output of VPC module - https://registry.terraform.io/modules/aws-ia/vpc/aws/latest."
 }
+
+# AWS NETWORK FIREWALL
+output "aws_network_firewall" {
+  value       = { for k, v in try(module.network_firewall, {}) : k => v.aws_network_firewall }
+  description = "AWS Network Firewall. Full output of aws_networkfirewall_firewall."
+}

--- a/tests/examples_central_vpcs_inspection.hcl
+++ b/tests/examples_central_vpcs_inspection.hcl
@@ -1,0 +1,18 @@
+run "core_network" {
+  command = apply
+
+  plan_options {
+    target = [module.cloud_wan]
+  }
+
+  module {
+    source = "./examples/central_vpcs_inspection"
+  }
+}
+
+run "validate" {
+  command = apply
+  module {
+    source = "./examples/central_vpcs_inspection"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,6 @@ variable "global_network" {
     This variable expects the following attributes:
     - `description` = (string) Global Network's description.
     - `tags`        = (Optional|map(string)) Tags to apply to the Global Network.
-    ```
 EOF
   type        = any
   default     = {}
@@ -120,6 +119,39 @@ variable "ipv4_network_definition" {
   description = "Definition of the IPv4 CIDR blocks of the AWS network - needed for the VPC routes in Ingress and Egress VPC types. You can specific either a CIDR range or a Prefix List ID."
 
   default = null
+}
+
+# ---------- AWS NETWORK FIREWALL ----------
+variable "aws_network_firewall" {
+  description = <<-EOF
+    AWS Network Firewall configuration. This variable expect a map of Network Firewall definitions to create a firewall resource (and corresponding VPC routing to firewall endpoints) in the corresponding VPC. The central VPC to create the resources is specified by using the same map key as in var.central_vpcs. Resources will be created only in VPC types `inspection`, `egress_with_inspection`, and `ingress_with_inspection`.
+    Each map item expects the following attributes:
+    - `name`                     = (string) Name of the AWS Network Firewall resource.
+    - `description`              = (string) Description of the AWS Network Firewall resource.
+    - `policy_arn`               = (string) ARN of the Network Firewall Policy.
+    - `delete_protection`        = (Optional|bool) Indicates whether it is possible to delete the firewall. Defaults to `false`.
+    - `policy_change_protection` = (Optional|bool) Indicates whether it is possible to change the firewall policy. Defaults to `false`.
+    - `subnet_change_protection` = (Optional|bool) Indicates whether it is possible to change the associated subnet(s) after creation. Defaults to `false`.
+    - `tags`                     = (Optional|map(string)) Tags to apply to the AWS Network Firewall resource.
+EOF
+  type        = any
+  default     = {}
+
+  # Key values for AWS Network Firewall definitions
+  validation {
+    error_message = "Valid key values each AWS Network Firewall definition: \"name\", \"description\", \"policy_arn\", \"delete_protection\", \"policy_change_protection\", \"subnet_change_protection\", \"tags\"."
+    condition = alltrue([
+      for vpc in try(var.aws_network_firewall, {}) : length(setsubtract(keys(vpc), [
+        "name",
+        "description",
+        "policy_arn",
+        "delete_protection",
+        "policy_change_protection",
+        "subnet_change_protection",
+        "tags"
+      ])) == 0
+    ])
+  }
 }
 
 # ---------- TAGS ----------


### PR DESCRIPTION
- Support for creation of AWS Network Firewall resources in central VPCs type `inspection`, `egress_with_inspection`, and `ingress_with_inspection`.
- New example: Central VPCs with AWS Network Firewall resources.
- README updates.