### PR TITLE
chore: bump version of aws-ia/label/aws module

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,11 +773,11 @@ As described in the error itself, you first need to create the IPAM pool to then
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_central_vpcs"></a> [central\_vpcs](#module\_central\_vpcs) | aws-ia/vpc/aws | 4.4.1 |
-| <a name="module_core_network_tags"></a> [core\_network\_tags](#module\_core\_network\_tags) | aws-ia/label/aws | 0.0.5 |
-| <a name="module_global_network_tags"></a> [global\_network\_tags](#module\_global\_network\_tags) | aws-ia/label/aws | 0.0.5 |
+| <a name="module_core_network_tags"></a> [core\_network\_tags](#module\_core\_network\_tags) | aws-ia/label/aws | 0.0.6 |
+| <a name="module_global_network_tags"></a> [global\_network\_tags](#module\_global\_network\_tags) | aws-ia/label/aws | 0.0.6 |
 | <a name="module_network_firewall"></a> [network\_firewall](#module\_network\_firewall) | aws-ia/networkfirewall/aws | 1.0.0 |
 | <a name="module_public_subnet_cidrs"></a> [public\_subnet\_cidrs](#module\_public\_subnet\_cidrs) | ./modules/subnet_cidrs | n/a |
-| <a name="module_tags"></a> [tags](#module\_tags) | aws-ia/label/aws | 0.0.5 |
+| <a name="module_tags"></a> [tags](#module\_tags) | aws-ia/label/aws | 0.0.6 |
 
 ## Resources
 

--- a/data.tf
+++ b/data.tf
@@ -97,21 +97,21 @@ data "aws_prefix_list" "ipv4_network_definition" {
 # ---------- SANITIZES TAGS ---------
 module "tags" {
   source  = "aws-ia/label/aws"
-  version = "0.0.5"
+  version = "0.0.6"
 
   tags = var.tags
 }
 
 module "global_network_tags" {
   source  = "aws-ia/label/aws"
-  version = "0.0.5"
+  version = "0.0.6"
 
   tags = try(var.global_network.tags, {})
 }
 
 module "core_network_tags" {
   source  = "aws-ia/label/aws"
-  version = "0.0.5"
+  version = "0.0.6"
 
   tags = try(var.core_network.tags, {})
 }


### PR DESCRIPTION
Recently, we encountered the error: "Could not retrieve the list of available versions for provider hashicorp/awscc: no available releases match the given constraints > 0.9,>= 0.15.0, >= 1.0.0" while using this module alongside other AWS modules due to the version constraint "> 0.9" specified by version 0.0.5 of the [terraform-aws-label module](https://github.com/aws-ia/terraform-aws-label). To address this, I updated the code to use version 0.0.06 of the terraform-aws-label module, which has a version constraint of ">= 1.0".