### PR TITLE
set region "us-east-1" on aws ram resources

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -9,6 +9,8 @@ locals {
   create_base_policy = (try(var.core_network.base_policy_document, null) == null) && (try(var.core_network.base_policy_regions, null) == null) ? false : true
   # RAM Resources
   create_ram_resources = try(var.core_network.resource_share_name, null) != null
+  # to share core network (global service) use AWS RAM from us-east-1 https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-share-network.html
+  ram_global_region = "us-east-1"
 
   # ---------- CENTRAL VPC - SUBNETS CONFIGURATION ----------
   subnets = {

--- a/examples/core_network_share/README.md
+++ b/examples/core_network_share/README.md
@@ -1,9 +1,13 @@
 <!-- BEGIN_TF_DOCS -->
+
 # AWS Cloud WAN Module - Sharing Core Network
 
-This example creates an AWS Network Manager Global Network and Core Network from scratch, sharing the Core Network with the AWS Account provided in the `aws_account_share` - we recommend the use of a *terraform.tfvars* file to indicate the AWS Account in your testing environment.
+This example creates an AWS Network Manager Global Network and Core Network from scratch, sharing the Core Network with
+the AWS Account provided in the `aws_account_share` - we recommend the use of a *terraform.tfvars* file to indicate the
+AWS Account in your testing environment.
 
-**Remember that if you are using the AWS Cloud WAN to share the Core Network, you need to create the resources in us-east-1 (North Virginia)**
+**Remember that if you are using the AWS Cloud WAN to share the Core Network, you need to share the resources with AWS
+RAM in us-east-1 (North Virginia)**
 
 ## Usage
 
@@ -13,42 +17,43 @@ This example creates an AWS Network Manager Global Network and Core Network from
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21.0 |
+| Name                                                                      | Version   |
+|---------------------------------------------------------------------------|-----------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0  |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 5.21.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
+| Name                                              | Version   |
+|---------------------------------------------------|-----------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.21.0 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_cloud_wan"></a> [cloud\_wan](#module\_cloud\_wan) | ../.. | n/a |
+| Name                                                              | Source | Version |
+|-------------------------------------------------------------------|--------|---------|
+| <a name="module_cloud_wan"></a> [cloud\_wan](#module\_cloud\_wan) | ../..  | n/a     |
 
 ## Resources
 
-| Name | Type |
-|------|------|
+| Name                                                                                                                                                                                 | Type        |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
 | [aws_networkmanager_core_network_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document) | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_aws_account_share"></a> [aws\_account\_share](#input\_aws\_account\_share) | AWS Account ID (to share the Core Network) | `string` | n/a | yes |
-| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region. | `string` | `"us-east-1"` | no |
-| <a name="input_identifier"></a> [identifier](#input\_identifier) | Example identifier. | `string` | `"core-network-share"` | no |
+| Name                                                                                      | Description                                | Type     | Default                | Required |
+|-------------------------------------------------------------------------------------------|--------------------------------------------|----------|------------------------|:--------:|
+| <a name="input_aws_account_share"></a> [aws\_account\_share](#input\_aws\_account\_share) | AWS Account ID (to share the Core Network) | `string` | n/a                    |   yes    |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region)                        | AWS Region.                                | `string` | `"us-east-1"`          |    no    |
+| <a name="input_identifier"></a> [identifier](#input\_identifier)                          | Example identifier.                        | `string` | `"core-network-share"` |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_core_network_id"></a> [core\_network\_id](#output\_core\_network\_id) | Core Network ID. |
-| <a name="output_global_network_id"></a> [global\_network\_id](#output\_global\_network\_id) | Global Network ID. |
+| Name                                                                                           | Description             |
+|------------------------------------------------------------------------------------------------|-------------------------|
+| <a name="output_core_network_id"></a> [core\_network\_id](#output\_core\_network\_id)          | Core Network ID.        |
+| <a name="output_global_network_id"></a> [global\_network\_id](#output\_global\_network\_id)    | Global Network ID.      |
 | <a name="output_ram_resource_share"></a> [ram\_resource\_share](#output\_ram\_resource\_share) | AWS RAM Resource Share. |
+
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ resource "aws_ram_resource_share" "resource_share" {
 
   name                      = var.core_network.resource_share_name
   allow_external_principals = try(var.core_network.resource_share_allow_external_principals, null)
+  region                    = local.ram_global_region
 
   tags = merge(
     module.tags.tags_aws,
@@ -58,6 +59,7 @@ resource "aws_ram_resource_association" "resource_association" {
 
   resource_arn       = aws_networkmanager_core_network.core_network[0].arn
   resource_share_arn = aws_ram_resource_share.resource_share[0].arn
+  region             = local.ram_global_region
 }
 
 # RAM Principal Association
@@ -66,6 +68,7 @@ resource "aws_ram_principal_association" "principal_association" {
 
   principal          = var.core_network.ram_share_principals[count.index]
   resource_share_arn = aws_ram_resource_share.resource_share[0].arn
+  region             = local.ram_global_region
 }
 
 # ---------- CENTRAL VPCS ----------


### PR DESCRIPTION
set region "us-east-1" on aws ram resources https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_association#region-1

Core Network can be shared only with AWS RAM in "us-east-1"